### PR TITLE
feat: update test fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ where = ["src"]
 dev = [
     "pip-audit>=2.10.0",
     "pre-commit>=4.5.1",
-    "pytest>=9.0.2",
+    "pytest>=9.0.3",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/eval_harness.py
+++ b/tests/eval_harness.py
@@ -1,4 +1,4 @@
-# tests/harness.py
+# tests/eval_harness.py
 from __future__ import annotations
 
 import ollama as _ollama

--- a/tests/evals/__init__.py
+++ b/tests/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Live evaluation tests."""

--- a/tests/evals/conftest.py
+++ b/tests/evals/conftest.py
@@ -1,8 +1,8 @@
-# tests/conftest.py
 from __future__ import annotations
 
 import pytest
-from tests.harness import OllamaEmbedFn, OllamaFn, is_ollama_running
+
+from tests.eval_harness import OllamaEmbedFn, OllamaFn, is_ollama_running
 
 
 @pytest.fixture(scope="session")

--- a/tests/evals/test_eval_harness.py
+++ b/tests/evals/test_eval_harness.py
@@ -1,8 +1,10 @@
-# tests/evals/test_harness.py
+# tests/evals/test_eval_harness.py
 from __future__ import annotations
 
 import uuid
+
 import pytest
+
 from anchor import Anchor
 from anchor.memory import ChromaMemoryStore
 
@@ -16,7 +18,7 @@ SEED_CHUNKS = [
 
 @pytest.fixture
 def anchor(ai_fn, light_ai_fn, embed_fn):
-    collection_name = f"test_harness_{uuid.uuid4().hex}"
+    collection_name = f"eval_harness_{uuid.uuid4().hex}"
     memory_store = ChromaMemoryStore(collection_name=collection_name)
     instance = Anchor(
         ai_fn=ai_fn,
@@ -35,8 +37,8 @@ def anchor(ai_fn, light_ai_fn, embed_fn):
 
 @pytest.mark.eval
 @pytest.mark.parametrize("run_number", range(5))
-def test_harness_single_hop(anchor, run_number):
-    """Sanity check — anchor retrieves a seeded fact and returns DONE."""
+def test_eval_harness_single_hop(anchor, run_number):
+    """Sanity check - anchor retrieves a seeded fact and returns DONE."""
     result = anchor.run("What is the project codename?")
     assert result.stop_reason == "done", f"Expected done, got {result.stop_reason!r}"
     assert (

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic unit tests."""

--- a/tests/unit/test_unit_harness.py
+++ b/tests/unit/test_unit_harness.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from anchor.ingestor import Ingestor
+from anchor.retriever import Retriever
+from tests.unit_harness import FakeMemoryStore, deterministic_embedding, scripted_model
+
+
+def test_unit_harness_supports_offline_ingest_and_retrieval() -> None:
+    store = FakeMemoryStore()
+    ingestor = Ingestor(
+        store,
+        deterministic_embedding,
+        question_fn=scripted_model("alpha?\nbeta?"),
+    )
+
+    chunk_id = ingestor.ingest("alpha project notes", source="docs")
+    store.queue_query_result(
+        [
+            {
+                "id": chunk_id,
+                "content": "alpha project notes",
+                "metadata": {"source": "docs", "questions": "alpha?\nbeta?"},
+                "source": "docs",
+                "score": 1.0,
+            }
+        ]
+    )
+
+    record = store.get(chunk_id)
+    assert record is not None
+    assert record["id"] == chunk_id
+    assert record["content"] == "alpha project notes"
+    assert record["metadata"]["source"] == "docs"
+    assert record["metadata"]["questions"] == "alpha?\nbeta?"
+    assert "timestamp" in record["metadata"]
+
+    retriever = Retriever(store, deterministic_embedding)
+    assert retriever.retrieve("alpha", top_k=1) == [
+        {
+            "id": chunk_id,
+            "content": "alpha project notes",
+            "metadata": {"source": "docs", "questions": "alpha?\nbeta?"},
+            "source": "docs",
+            "score": 1.0,
+        }
+    ]

--- a/tests/unit_harness.py
+++ b/tests/unit_harness.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import copy
+
+from anchor.memory import MemoryStore
+
+
+class ScriptedModel:
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = list(responses)
+        self.calls: list[list[dict]] = []
+
+    def __call__(self, messages: list[dict]) -> str:
+        self.calls.append(copy.deepcopy(messages))
+        if not self.responses:
+            raise AssertionError("No scripted model responses left.")
+
+        return self.responses.pop(0)
+
+
+def scripted_model(*responses: str) -> ScriptedModel:
+    return ScriptedModel(list(responses))
+
+
+def deterministic_embedding(text: str) -> list[float]:
+    counts = [0.0] * 27
+    for char in text.lower():
+        if "a" <= char <= "z":
+            counts[ord(char) - ord("a")] += 1.0
+        elif char.isdigit():
+            counts[26] += float(ord(char) - ord("0"))
+
+    total = sum(counts) or 1.0
+    return [value / total for value in counts]
+
+
+class FakeMemoryStore(MemoryStore):
+    def __init__(
+        self,
+        *,
+        query_results: list[list[dict]] | None = None,
+        get_results: dict[str, dict | None] | None = None,
+        allow_fallback_query: bool = False,
+    ) -> None:
+        self.items: dict[str, dict] = {}
+        self.query_results = list(query_results or [])
+        self.get_results = dict(get_results or {})
+        self.allow_fallback_query = allow_fallback_query
+
+    def queue_query_result(self, results: list[dict]) -> None:
+        self.query_results.append(copy.deepcopy(results))
+
+    def add(self, id: str, text: str, embedding: list[float], metadata: dict) -> None:
+        self.items[id] = {
+            "id": id,
+            "content": text,
+            "embedding": list(embedding),
+            "metadata": dict(metadata),
+        }
+
+    def query(self, embedding: list[float], top_k: int = 5) -> list[dict]:
+        if self.query_results:
+            return copy.deepcopy(self.query_results.pop(0))[:top_k]
+
+        if not self.allow_fallback_query:
+            raise AssertionError("No fake memory query result queued.")
+
+        return [
+            {
+                "id": item["id"],
+                "content": item["content"],
+                "metadata": dict(item["metadata"]),
+                "source": item["metadata"].get("source", "unknown"),
+                "score": 1.0,
+            }
+            for item in list(self.items.values())[:top_k]
+        ]
+
+    def delete(self, id: str) -> None:
+        self.items.pop(id, None)
+        self.get_results.pop(id, None)
+
+    def get(self, id: str) -> dict | None:
+        if id in self.get_results:
+            return copy.deepcopy(self.get_results[id])
+
+        item = self.items.get(id)
+        if item is None:
+            return None
+
+        return {
+            "id": item["id"],
+            "content": item["content"],
+            "metadata": dict(item["metadata"]),
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ requires-dist = [
 dev = [
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest", specifier = ">=9.0.3" },
 ]
 
 [[package]]
@@ -1417,7 +1417,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1426,9 +1426,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a shared offline unit test harness with scripted model responses, deterministic embeddings, and a fake in-memory `MemoryStore`. Splits live Ollama eval helpers into an eval-specific harness s deterministic tests can run without live dependencies.

## Linked context
Closes #10 

## PR Type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Prompt change (`prompt` label required; eval results required below)
- [x] Test
- [ ] Docs
- [ ] Refactor / chore

## Context / Motivation

Phase 1 deterministic test coverage needs reusable offline helpers so unit and integration tests do not need to recreate local fakes or depend on Ollama. This change establishes a small shared harness for deterministic tests while keeping live eval setup separate.


## Changes
- Added `tests/unit_harness.py` with `scripted_model`, `deterministic_embedding`, and `FakeMemoryStore`.
- Moved live Ollama helpers to `tests/eval_harness.py` and scoped eval fixtures under `tests/evals/conftest.py`.
- Renamed the eval harness test module for clearer separation from shared harness code.
- Added a minimal deterministic unit test covering offline ingest and retrieval through the new harness.
- Updated `pytest` to `>=9.0.3` to satisfy `pip-audit`.

## Checklist

- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.
