### PR TITLE
test: add loop protocol and max_remembers unit tests

### DIFF
--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.anchor import Anchor
+from tests.unit_harness import scripted_model
+
+
+def _make_anchor(
+    ai_responses: list[str],
+    light_ai_responses: list[str] | None = None,
+) -> Anchor:
+    return Anchor(
+        ai_fn=scripted_model(*ai_responses),
+        light_ai_fn=scripted_model(*(light_ai_responses or [])),
+    )
+
+
+@pytest.mark.unit
+def test_done_on_first_call() -> None:
+    anchor = _make_anchor(["The answer is 42.\nDONE"])
+    result = anchor.run("What is the answer?")
+    assert result.kind == "done"
+    assert result.stop_reason == "done"
+    assert result.content == "The answer is 42."
+
+
+@pytest.mark.unit
+def test_single_remember_then_done() -> None:
+    anchor = _make_anchor(
+        ai_responses=[
+            "GAP: what is X?\nCONTEXT: figuring out X\nREMEMBER",
+            "The answer is X.\nDONE",
+        ],
+        light_ai_responses=["query about X"],
+    )
+    result = anchor.run("Tell me about X.")
+    assert result.kind == "done"
+    assert result.stop_reason == "done"
+    assert result.content == "The answer is X."
+
+
+@pytest.mark.unit
+def test_two_remembers_then_done() -> None:
+    anchor = _make_anchor(
+        ai_responses=[
+            "GAP: what is X?\nCONTEXT: figuring out X\nREMEMBER",
+            "GAP: what is Y?\nCONTEXT: still working through it\nREMEMBER",
+            "The final answer.\nDONE",
+        ],
+        light_ai_responses=["query about X", "query about Y"],
+    )
+    result = anchor.run("Tell me about X and Y.")
+    assert result.kind == "done"
+    assert result.stop_reason == "done"
+    assert result.content == "The final answer."
+
+
+@pytest.mark.unit
+def test_clarify_path() -> None:
+    anchor = _make_anchor(["QUESTION: Which format do you want?\nCLARIFY"])
+    result = anchor.run("Process the data.")
+    assert result.kind == "ask"
+    assert result.stop_reason == "ask"
+    assert "Which format do you want?" in result.content
+
+
+@pytest.mark.unit
+def test_no_marker_error_path() -> None:
+    # no protocol marker => loop exits with stop_reason="error"; kind is still "done"
+    anchor = _make_anchor(["Just some text with no protocol marker."])
+    result = anchor.run("What is this?")
+    assert result.kind == "done"
+    assert result.stop_reason == "error"
+
+
+@pytest.mark.unit
+def test_max_remembers_guard() -> None:
+    # max_remembers=2 => the 3rd REMEMBER triggers exit (remembers=3 > 2)
+    anchor = _make_anchor(
+        ai_responses=[
+            "GAP: gap1\nCONTEXT: ctx1\nREMEMBER",
+            "GAP: gap2\nCONTEXT: ctx2\nREMEMBER",
+            "GAP: gap3\nCONTEXT: ctx3\nREMEMBER",
+        ],
+        light_ai_responses=["query1", "query2"],
+    )
+    anchor.MAX_REMEMBERS = 2
+    result = anchor.run("Something that requires many lookups.")
+    assert result.kind == "done"
+    assert result.stop_reason == "max_remembers"


### PR DESCRIPTION
# Pull Request
`test: add loop protocol and max_remembers unit tests`

## Summary

Adds offline unit tests for the core orchestrator loop covering all protocol exit paths (DONE, REMEMBER, CLARIFY, no-marker) and the max_remembers guard. The loop was the most critical component with zero unit test coverage.

<!-- REQUIRED -->
<!-- Keep this heading name: automation reads it -->
Closes #11 and #12 

## PR Size

<!-- REQUIRED: check one -->

- [✔] Small (< 100 LOC delta)
- [ ] Medium (100-499 LOC delta)
- [ ] Large (500-999 LOC delta)
- [ ] XL (1000+ LOC delta — must have been pre-discussed in an issue)

## PR Type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Prompt change (`prompt` label required; eval results required below)
- [✔] Test
- [ ] Docs
- [ ] Refactor / chore

## Context / Motivation

<!-- REQUIRED -->
The orchestrator loop in `loop.py` drives all of Anchor's core behavior but had no unit tests. `ScriptedModel` and `FakeMemoryStore` were already available in `unit_harness.py` to support fully offline testing, so this PR puts them to use on the most critical path in the codebase.

## Changes

<!-- REQUIRED -->
Added `tests/unit/test_loop.py` with 6 unit tests covering: DONE on first call, single REMEMBER cycle, chained REMEMBER cycles, CLARIFY path, no-marker error path (`stop_reason="error", kind="done"`), and max_remembers guard exit

## How to test

<!-- Optional for small PRs; recommended for all -->

1. `uv run pytest -m unit -v`
2. All 6 tests in `test_loop.py` should pass with no Ollama or network dependency

## Prompt Change Eval Results

<!-- Required if PR Type includes "Prompt change"; skip otherwise -->
<!-- Run: uv run pytest -m eval tests/evals -->
<!-- Preferred model: llama3:8b via Ollama -->

<details>
<summary>Full eval output (optional)</summary>

```text
<paste here>
```

</details>

## Checklist

- [✔] I ran the relevant local checks.
- [✔] I updated documentation or confirmed no docs changes were needed.
- [✔] I linked related issues or pull requests and confirmed this is not duplicate work.
- [✔] This change stays within the stated scope of the PR.

## Notes for reviewers

Call out any tradeoffs, follow-up work, or setup needed to validate the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for loop control flow validation, including termination states, clarification requests, error conditions, and memory limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->