### PR TITLE
test: add retriever deterministic unit tests

### DIFF
--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -17,9 +17,14 @@ class _SpyStore(MemoryStore):
         self.query_calls.append((list(embedding), top_k))
         return list(self._results)
 
-    def add(self, id, text, embedding, metadata): ...  # noqa: E704
-    def delete(self, id): ...  # noqa: E704
-    def get(self, id): ...  # noqa: E704
+    def add(self, id, text, embedding, metadata):  # noqa: A002
+        raise NotImplementedError
+
+    def delete(self, id):  # noqa: A002
+        raise NotImplementedError
+
+    def get(self, id):  # noqa: A002
+        raise NotImplementedError
 
 
 @pytest.mark.unit

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.memory import MemoryStore
+from anchor.retriever import Retriever
+
+
+class _SpyStore(MemoryStore):
+    """Minimal MemoryStore that records query calls and returns canned results."""
+
+    def __init__(self, results: list[dict]) -> None:
+        self._results = results
+        self.query_calls: list[tuple[list[float], int]] = []
+
+    def query(self, embedding: list[float], top_k: int = 5) -> list[dict]:
+        self.query_calls.append((list(embedding), top_k))
+        return list(self._results)
+
+    def add(self, id, text, embedding, metadata): ...  # noqa: E704
+    def delete(self, id): ...  # noqa: E704
+    def get(self, id): ...  # noqa: E704
+
+
+@pytest.mark.unit
+def test_retrieve_passes_query_to_embed_fn_and_returns_chunks() -> None:
+    captured: list[str] = []
+    embedding = [0.1, 0.2, 0.3]
+    chunks = [{"id": "c1", "content": "hello", "metadata": {}, "score": 0.9}]
+
+    def fake_embed(text: str) -> list[float]:
+        captured.append(text)
+        return embedding
+
+    store = _SpyStore(chunks)
+    result = Retriever(store, fake_embed).retrieve("what is X?", top_k=3)
+
+    assert captured == ["what is X?"]
+    assert store.query_calls == [(embedding, 3)]
+    assert result == chunks
+
+
+@pytest.mark.unit
+def test_retrieve_default_top_k() -> None:
+    embedding = [0.5]
+    store = _SpyStore([])
+
+    Retriever(store, lambda _: embedding).retrieve("anything")
+
+    assert store.query_calls == [([0.5], 2)]
+
+
+@pytest.mark.unit
+def test_retrieve_chunks_returned_unchanged() -> None:
+    chunks = [
+        {"id": "a", "content": "foo", "metadata": {"source": "s"}, "score": 0.8},
+        {"id": "b", "content": "bar", "metadata": {"source": "s"}, "score": 0.7},
+    ]
+    store = _SpyStore(chunks)
+
+    result = Retriever(store, lambda _: [0.0]).retrieve("q", top_k=5)
+
+    assert result == chunks
+
+
+@pytest.mark.unit
+def test_retrieve_raises_without_embed_fn() -> None:
+    store = _SpyStore([])
+
+    with pytest.raises(RuntimeError, match="No embedding function"):
+        Retriever(store, None).retrieve("query")


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds offline unit tests for `Retriever.retrieve()` verifying the adapter contract: query string reaches `embed_fn`, the resulting embedding and `top_k` are forwarded to `memory_store.query`, and chunks are returned unchanged. Also covers the missing `embed_fn` error path.

## Linked context
Closes #16

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] Test

## Context / Motivation
`Retriever` had no unit tests despite defining a clear contract between the embedding function and memory store. This PR documents and enforces that contract with fully offline tests.

## Changes
Added `tests/unit/test_retriever.py` with 4 tests: normal retrieval path, default `top_k=2`, multi-chunk passthrough, and `RuntimeError` on missing `embed_fn`. Uses a small inline `_SpyStore` to record calls without any Chroma or live embedding dependency.

## How to test
1. `uv run pytest -m unit -v`
2. All 4 tests in `test_retriever.py` should pass with no network or Ollama dependency

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
`test_retrieve_default_top_k` asserts `top_k=2`, which follows the current hardcoded default in `retriever.py`, rather than endorsing it. Exposing `top_k` through `AnchorConfig` would be a separate improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for retrieval behavior: verifies the embedding function is called with the original query, that the resulting embedding and requested top_k are forwarded to the store, that top_k defaults to 2 when omitted, and that constructing without an embedding function raises an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->