### PR TITLE
test: add loop helper parsing tests

### DIFF
--- a/tests/unit/test_loop_helpers.py
+++ b/tests/unit/test_loop_helpers.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.loop import Loop
+
+
+@pytest.fixture
+def loop() -> Loop:
+    # Helpers under test are pure and do not touch the Anchor instance,
+    # so we pass None to keep the tests free of model/embedding wiring.
+    return Loop(anchor=None)
+
+
+# ---------------------------------------------------------------------------
+# _extract_gap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_gap_standard_input(loop: Loop) -> None:
+    content = "GAP: what is X?\nCONTEXT: figuring out X\nREMEMBER"
+    gap, context = loop._extract_gap(content)
+    assert gap == "what is X?"
+    assert context == "figuring out X"
+
+
+@pytest.mark.unit
+def test_extract_gap_missing_gap(loop: Loop) -> None:
+    content = "CONTEXT: still working through it\nREMEMBER"
+    gap, context = loop._extract_gap(content)
+    assert gap == ""
+    assert context == "still working through it"
+
+
+@pytest.mark.unit
+def test_extract_gap_missing_context(loop: Loop) -> None:
+    content = "GAP: what is Y?\nREMEMBER"
+    gap, context = loop._extract_gap(content)
+    assert gap == "what is Y?"
+    assert context == ""
+
+
+@pytest.mark.unit
+def test_extract_gap_both_missing(loop: Loop) -> None:
+    content = "Some unrelated reasoning text.\nNo markers here.\nDONE"
+    gap, context = loop._extract_gap(content)
+    assert gap == ""
+    assert context == ""
+
+
+@pytest.mark.unit
+def test_extract_gap_handles_extra_whitespace_and_blank_lines(loop: Loop) -> None:
+    content = (
+        "\n   GAP:   what is Z?   \n\n   CONTEXT:\treasoning about Z\t\n\nREMEMBER\n"
+    )
+    gap, context = loop._extract_gap(content)
+    assert gap == "what is Z?"
+    assert context == "reasoning about Z"
+
+
+# ---------------------------------------------------------------------------
+# _strip_marker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_strip_marker_removes_trailing_marker(loop: Loop) -> None:
+    content = "The answer is 42.\nDONE"
+    assert loop._strip_marker(content, "DONE") == "The answer is 42."
+
+
+@pytest.mark.unit
+def test_strip_marker_cleans_trailing_blank_lines_before_marker(loop: Loop) -> None:
+    content = "The answer is 42.\n\n\nDONE\n\n"
+    assert loop._strip_marker(content, "DONE") == "The answer is 42."
+
+
+@pytest.mark.unit
+def test_strip_marker_preserves_content_without_marker(loop: Loop) -> None:
+    content = "The answer is 42.\nNo marker here."
+    assert loop._strip_marker(content, "DONE") == "The answer is 42.\nNo marker here."
+
+
+@pytest.mark.unit
+def test_strip_marker_only_strips_final_marker_occurrence(loop: Loop) -> None:
+    # The marker appears twice: once embedded in prose and once as the true
+    # terminal marker. Only the terminal one should be removed.
+    content = "I initially wrote DONE by mistake.\nHere's the real answer.\nDONE"
+    expected = "I initially wrote DONE by mistake.\nHere's the real answer."
+    assert loop._strip_marker(content, "DONE") == expected
+
+
+@pytest.mark.unit
+def test_strip_marker_does_not_strip_when_marker_is_substring_of_last_line(
+    loop: Loop,
+) -> None:
+    # The last line contains the marker text but is not *exactly* the marker,
+    # so nothing should be stripped.
+    content = "Final thought.\nI am DONE reasoning now."
+    assert loop._strip_marker(content, "DONE") == content
+
+
+@pytest.mark.unit
+def test_strip_marker_handles_marker_with_surrounding_whitespace(loop: Loop) -> None:
+    # The final line is "   DONE   ", which after stripping equals the marker,
+    # so it should still be removed.
+    content = "The answer is 42.\n   DONE   "
+    assert loop._strip_marker(content, "DONE") == "The answer is 42."


### PR DESCRIPTION
# Pull Request

## Summary

Adds deterministic unit tests for the helper parsing behavior in `src/anchor/loop.py`. This PR covers `_extract_gap()` and `_strip_marker()` with focused offline tests so regressions in loop protocol parsing are easier to catch and debug.

## Linked context

Closes #13

## PR Size

- [x] Small (< 100 LOC delta)
- [ ] Medium (100-499 LOC delta)
- [ ] Large (500-999 LOC delta)
- [ ] XL (1000+ LOC delta — must have been pre-discussed in an issue)

## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Prompt change (`prompt` label required; eval results required below)
- [x] Test
- [ ] Docs
- [ ] Refactor / chore

## Context / Motivation

These helpers are small, but they are responsible for parsing `GAP:` / `CONTEXT:` content emitted by the loop protocol and for stripping terminal markers from returned text. Adding focused tests helps catch regressions without expanding into full `Anchor.run()` integration coverage.

## Changes

Added `tests/unit/test_loop_helpers.py` with deterministic unit tests for `_extract_gap()` and `_strip_marker()`, covering standard parsing, missing markers, whitespace handling, and terminal marker stripping behavior.

## How to test

1. `uv run pytest -m "not eval" tests/unit/test_loop_helpers.py -v`
2. `uv run pytest -m "not eval"`
3. `uv run pre-commit run --all-files`

## Checklist

- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers

This PR stays intentionally narrow and only adds helper-level unit tests. No production code or protocol behavior was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Expanded test coverage for internal helper methods to enhance code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->