### PR TITLE
test: add unit tests for Decomposer._normalize

### DIFF
--- a/tests/unit/test_decomposer_normalize.py
+++ b/tests/unit/test_decomposer_normalize.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.decomposer import Decomposer
+
+
+@pytest.fixture
+def decomposer() -> Decomposer:
+    # _normalize() does not call the model, so a no-op model_fn is fine.
+    return Decomposer(model_fn=lambda _messages: "")
+
+
+# ---------------------------------------------------------------------------
+# numbered prefixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_strips_dot_numbered_prefix(decomposer: Decomposer) -> None:
+    assert decomposer._normalize("1. question") == "question"
+
+
+@pytest.mark.unit
+def test_normalize_strips_paren_numbered_prefix(decomposer: Decomposer) -> None:
+    assert decomposer._normalize("2) question") == "question"
+
+
+# ---------------------------------------------------------------------------
+# bullet prefixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_strips_hyphen_bullet(decomposer: Decomposer) -> None:
+    assert decomposer._normalize("- question") == "question"
+
+
+@pytest.mark.unit
+def test_normalize_strips_asterisk_bullet(decomposer: Decomposer) -> None:
+    assert decomposer._normalize("* question") == "question"
+
+
+# ---------------------------------------------------------------------------
+# already-normalized and no-op cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_preserves_plain_text(decomposer: Decomposer) -> None:
+    assert decomposer._normalize("plain question") == "plain question"
+
+
+@pytest.mark.unit
+def test_normalize_trims_surrounding_whitespace(decomposer: Decomposer) -> None:
+    assert decomposer._normalize("   plain question   ") == "plain question"
+
+
+@pytest.mark.unit
+def test_normalize_handles_padded_prefix(decomposer: Decomposer) -> None:
+    # The helper strips the outer whitespace first, then the list prefix.
+    assert decomposer._normalize("   2) padded query  ") == "padded query"
+
+
+# ---------------------------------------------------------------------------
+# blank / whitespace-only input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("blank", ["", " ", "   ", "\t", "\n", "\t\n  "])
+def test_normalize_returns_empty_string_for_blank_input(
+    decomposer: Decomposer, blank: str
+) -> None:
+    assert decomposer._normalize(blank) == ""


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `test: add unit tests for Decomposer._normalize`

## Summary

Adds deterministic unit tests for `Decomposer._normalize` to ensure consistent handling of list prefixes and whitespace in model output.

## Linked context

Closes #14

## PR Size

- [x] Small (< 100 LOC delta)
- [ ] Medium (100-499 LOC delta)
- [ ] Large (500-999 LOC delta)
- [ ] XL (1000+ LOC delta — must have been pre-discussed in an issue)

## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Prompt change (`prompt` label required; eval results required below)
- [x] Test
- [ ] Docs
- [ ] Refactor / chore

## Context / Motivation

The `_normalize` helper cleans raw model output lines before they are converted into retrieval queries. Adding deterministic tests ensures reliable handling of numbered prefixes, bullet prefixes, and whitespace, helping prevent regressions.

## Changes

Added `tests/unit/test_decomposer_normalize.py` with unit tests covering numbered prefixes, bullet prefixes, already-normalized text, whitespace trimming, blank input, and padded prefix cases.

## How to test

1. Run:
   ```bash
   uv run pytest -m "not eval"

## Prompt Change Eval Results

<!-- Required if PR Type includes "Prompt change"; skip otherwise -->
<!-- Run: uv run pytest -m eval tests/evals -->
<!-- Preferred model: llama3:8b via Ollama -->

<details>
<summary>Full eval output (optional)</summary>

```text
<paste here>
```

</details>

## Checklist

- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers

This PR only adds deterministic unit tests and does not modify any existing logic or prompt behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for text normalization functionality, including stripping numbered list prefixes (1. and 2) formats), removing bullet points (- and *), trimming surrounding whitespace, and handling edge cases with blank or whitespace-only inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->