### PR TITLE
test: add decomposer prompt-construction unit tests

### DIFF
--- a/tests/unit/test_decomposer_prompts.py
+++ b/tests/unit/test_decomposer_prompts.py
@@ -15,12 +15,7 @@ def _spy_model(response: str = ""):
 
     return model_fn, prompts
 
-
-# ---------------------------------------------------------------------------
 # No-retrieval prompt path
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 def test_no_retrieval_prompt_contains_grounding_language() -> None:
     gap = "What is the capital of France?"
@@ -34,11 +29,7 @@ def test_no_retrieval_prompt_contains_grounding_language() -> None:
     assert f"User question: {gap}" in prompt
 
 
-# ---------------------------------------------------------------------------
 # Retrieval-aware prompt path
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 def test_retrieval_aware_prompt_contains_context_facts_and_rules() -> None:
     gap = "missing info about X"
@@ -55,12 +46,7 @@ def test_retrieval_aware_prompt_contains_context_facts_and_rules() -> None:
     assert "fact about X" in prompt
     assert "Rules:" in prompt
 
-
-# ---------------------------------------------------------------------------
 # History truncation — only last 6 of N messages included
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 def test_history_truncation_keeps_last_six() -> None:
     history = [{"role": "user", "content": f"msg{i}"} for i in range(8)]
@@ -74,12 +60,7 @@ def test_history_truncation_keeps_last_six() -> None:
     for i in range(2, 8):
         assert f"msg{i}" in prompt
 
-
-# ---------------------------------------------------------------------------
 # Retrieved items truncation — only first 8 of N items serialized
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 def test_retrieved_items_truncated_to_eight() -> None:
     retrieved = [
@@ -96,12 +77,7 @@ def test_retrieved_items_truncated_to_eight() -> None:
     assert "item8" not in prompt
     assert "item9" not in prompt
 
-
-# ---------------------------------------------------------------------------
 # Gap insertion
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 def test_gap_inserted_at_front_when_absent_from_model_output() -> None:
     gap = "What is project Omega?"

--- a/tests/unit/test_decomposer_prompts.py
+++ b/tests/unit/test_decomposer_prompts.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.decomposer import Decomposer
+
+
+def _spy_model(response: str = ""):
+    """Returns (model_fn, prompts). Each call appends the user-role prompt text."""
+    prompts: list[str] = []
+
+    def model_fn(messages: list[dict]) -> str:
+        prompts.append(messages[0]["content"])
+        return response
+
+    return model_fn, prompts
+
+
+# ---------------------------------------------------------------------------
+# No-retrieval prompt path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_retrieval_prompt_contains_grounding_language() -> None:
+    gap = "What is the capital of France?"
+    model_fn, prompts = _spy_model("query one\nquery two")
+
+    Decomposer(model_fn).decompose(gap)
+
+    prompt = prompts[0]
+    assert "grounded strictly in the user question below" in prompt
+    assert "Do not invent, assume, or reference entities not explicitly mentioned" in prompt
+    assert f"User question: {gap}" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Retrieval-aware prompt path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_retrieval_aware_prompt_contains_context_facts_and_rules() -> None:
+    gap = "missing info about X"
+    context = "We are processing project Alpha."
+    retrieved = [{"id": "r1", "questions": "q?", "content": "fact about X"}]
+    model_fn, prompts = _spy_model("query one\nquery two")
+
+    Decomposer(model_fn).decompose(gap, context=context, retrieved=retrieved)
+
+    prompt = prompts[0]
+    assert context in prompt
+    assert f"The AI says it's missing: {gap}" in prompt
+    assert "r1" in prompt
+    assert "fact about X" in prompt
+    assert "Rules:" in prompt
+
+
+# ---------------------------------------------------------------------------
+# History truncation — only last 6 of N messages included
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_history_truncation_keeps_last_six() -> None:
+    history = [{"role": "user", "content": f"msg{i}"} for i in range(8)]
+    model_fn, prompts = _spy_model("q")
+
+    Decomposer(model_fn).decompose("gap", history=history)
+
+    prompt = prompts[0]
+    assert "msg0" not in prompt
+    assert "msg1" not in prompt
+    for i in range(2, 8):
+        assert f"msg{i}" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Retrieved items truncation — only first 8 of N items serialized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_retrieved_items_truncated_to_eight() -> None:
+    retrieved = [
+        {"id": f"item{i}", "questions": "", "content": f"content{i}"}
+        for i in range(10)
+    ]
+    model_fn, prompts = _spy_model("q")
+
+    Decomposer(model_fn).decompose("gap", retrieved=retrieved)
+
+    prompt = prompts[0]
+    for i in range(8):
+        assert f"item{i}" in prompt
+    assert "item8" not in prompt
+    assert "item9" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Gap insertion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_gap_inserted_at_front_when_absent_from_model_output() -> None:
+    gap = "What is project Omega?"
+    model_fn, _ = _spy_model("query about something else\nanother query")
+
+    queries = Decomposer(model_fn).decompose(gap)
+
+    assert queries[0] == gap
+
+
+@pytest.mark.unit
+def test_gap_not_duplicated_when_already_in_model_output() -> None:
+    gap = "What is project Omega?"
+    model_fn, _ = _spy_model(f"{gap}\nsome other query")
+
+    queries = Decomposer(model_fn).decompose(gap)
+
+    assert queries.count(gap) == 1

--- a/tests/unit/test_decomposer_prompts.py
+++ b/tests/unit/test_decomposer_prompts.py
@@ -15,6 +15,7 @@ def _spy_model(response: str = ""):
 
     return model_fn, prompts
 
+
 # No-retrieval prompt path
 @pytest.mark.unit
 def test_no_retrieval_prompt_contains_grounding_language() -> None:
@@ -25,7 +26,10 @@ def test_no_retrieval_prompt_contains_grounding_language() -> None:
 
     prompt = prompts[0]
     assert "grounded strictly in the user question below" in prompt
-    assert "Do not invent, assume, or reference entities not explicitly mentioned" in prompt
+    assert (
+        "Do not invent, assume, or reference entities not explicitly mentioned"
+        in prompt
+    )
     assert f"User question: {gap}" in prompt
 
 
@@ -46,6 +50,7 @@ def test_retrieval_aware_prompt_contains_context_facts_and_rules() -> None:
     assert "fact about X" in prompt
     assert "Rules:" in prompt
 
+
 # History truncation — only last 6 of N messages included
 @pytest.mark.unit
 def test_history_truncation_keeps_last_six() -> None:
@@ -60,12 +65,12 @@ def test_history_truncation_keeps_last_six() -> None:
     for i in range(2, 8):
         assert f"msg{i}" in prompt
 
+
 # Retrieved items truncation — only first 8 of N items serialized
 @pytest.mark.unit
 def test_retrieved_items_truncated_to_eight() -> None:
     retrieved = [
-        {"id": f"item{i}", "questions": "", "content": f"content{i}"}
-        for i in range(10)
+        {"id": f"item{i}", "questions": "", "content": f"content{i}"} for i in range(10)
     ]
     model_fn, prompts = _spy_model("q")
 
@@ -76,6 +81,7 @@ def test_retrieved_items_truncated_to_eight() -> None:
         assert f"item{i}" in prompt
     assert "item8" not in prompt
     assert "item9" not in prompt
+
 
 # Gap insertion
 @pytest.mark.unit


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds deterministic offline tests for prompt construction in `Decomposer.decompose()`. Covers both prompt shapes (no-retrieval and retrieval-aware), history and retrieved-item truncation limits, and the gap-insertion behavior when the model output omits the raw gap.

## Linked context
Closes #15

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] Test

## Context / Motivation
`Decomposer` builds two distinct prompt shapes with specific grounding rules, truncation limits, and a gap-insertion contract, none of which had any test coverage. This PR pins that behavior so future prompt edits have a regression baseline.

## Changes
Added `tests/unit/test_decomposer_prompts.py` with 6 tests:
- No-retrieval prompt contains strict grounding language and the user question
- Retrieval-aware prompt contains context, serialized retrieved facts, and rules section
- History truncation keeps only the last 6 of N messages
- Retrieved items truncation serializes only the first 8 of N items
- Gap inserted at front of query list when absent from model output
- Gap not duplicated when model output already includes it

## How to test
1. `uv run pytest -m unit -v`
2. All 6 tests in `test_decomposer_prompts.py` should pass with no network or Ollama dependency

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
I noticed that the `_spy_model` helper captures `messages[0]["content"]`, which from my understanding, is the actual prompt string sent to the model. So do assertions read against real prompt text rather than mock call counts? The no-retrieval path test asserts specific substrings from the production prompt, but if grounding language is reworded in future, I think these tests will need to be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering prompt construction and gap-handling across two prompt modes (with and without retrieval).
  * Verifies inclusion of grounding/non-invention guidance, contextual facts, serialized retrieved item snippets, and a rules section.
  * Asserts history and retrieved-item truncation limits and correct gap insertion (no duplication when already present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->