### PR TITLE
test: add deterministic tests for MAX_REMEMBERS guard

### DIFF
--- a/tests/unit/test_loop_max_remembers.py
+++ b/tests/unit/test_loop_max_remembers.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.anchor import Anchor
+from tests.unit_harness import scripted_model
+
+# The REMEMBER protocol block the agent emits when it wants another retrieval
+# cycle. Pre-built here so each test stays readable and we can assert on the
+# exact content returned when the guard strips the terminal marker.
+REMEMBER_BODY = "GAP: still missing a fact\nCONTEXT: reasoning incomplete"
+REMEMBER_RESPONSE = f"{REMEMBER_BODY}\nREMEMBER"
+
+
+def _make_anchor(
+    ai_responses: list[str],
+    light_ai_responses: list[str] | None = None,
+) -> Anchor:
+    return Anchor(
+        ai_fn=scripted_model(*ai_responses),
+        light_ai_fn=scripted_model(*(light_ai_responses or [])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# guard fires and returns the documented shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_guard_trips_when_remember_count_exceeds_limit() -> None:
+    # With MAX_REMEMBERS=2, the guard should fire on the 3rd REMEMBER response
+    # (remembers counter is incremented to 3 and then 3 > 2 returns True).
+    anchor = _make_anchor(
+        ai_responses=[REMEMBER_RESPONSE, REMEMBER_RESPONSE, REMEMBER_RESPONSE],
+        light_ai_responses=["q1", "q2"],
+    )
+    anchor.MAX_REMEMBERS = 2
+
+    result = anchor.run("question that never reaches DONE")
+
+    assert result.kind == "done"
+    assert result.stop_reason == "max_remembers"
+
+
+@pytest.mark.unit
+def test_guard_returns_content_without_trailing_remember_marker() -> None:
+    # When the guard fires, the final content returned to the caller should
+    # have the terminal REMEMBER stripped so users never see protocol tokens.
+    anchor = _make_anchor(
+        ai_responses=[REMEMBER_RESPONSE, REMEMBER_RESPONSE],
+        light_ai_responses=["q1"],
+    )
+    anchor.MAX_REMEMBERS = 1
+
+    result = anchor.run("question")
+
+    assert "REMEMBER" not in result.content.splitlines()[-1]
+    assert result.content == REMEMBER_BODY
+
+
+# ---------------------------------------------------------------------------
+# the guard is precise: it fires on N+1, not on N
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_guard_does_not_trip_on_exactly_max_remembers_when_final_response_is_done() -> (
+    None
+):
+    # MAX_REMEMBERS=2 means two REMEMBER cycles are allowed. A subsequent DONE
+    # on the third turn should resolve normally - the guard must NOT fire at
+    # remembers == max_remembers.
+    anchor = _make_anchor(
+        ai_responses=[REMEMBER_RESPONSE, REMEMBER_RESPONSE, "final answer\nDONE"],
+        light_ai_responses=["q1", "q2"],
+    )
+    anchor.MAX_REMEMBERS = 2
+
+    result = anchor.run("question")
+
+    assert result.kind == "done"
+    assert result.stop_reason == "done"
+    assert result.content == "final answer"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("max_remembers", [1, 2, 3, 5])
+def test_guard_trips_exactly_at_n_plus_one_remembers(max_remembers: int) -> None:
+    # For any MAX_REMEMBERS=N, queuing N+1 REMEMBER responses should end in
+    # max_remembers. Queue one extra DONE after the limit to prove the loop
+    # actually terminates on the guard and never consumes the DONE.
+    ai_responses = [REMEMBER_RESPONSE] * (max_remembers + 1) + ["never used\nDONE"]
+    light_ai_responses = ["decomposed"] * max_remembers
+
+    anchor = _make_anchor(
+        ai_responses=ai_responses, light_ai_responses=light_ai_responses
+    )
+    anchor.MAX_REMEMBERS = max_remembers
+
+    result = anchor.run("question")
+
+    assert result.stop_reason == "max_remembers"
+
+
+# ---------------------------------------------------------------------------
+# custom MAX_REMEMBERS on the instance and on a subclass both work
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_guard_respects_instance_level_max_remembers_override() -> None:
+    # Mutating MAX_REMEMBERS on the instance should override the class
+    # default, since the loop does a plain getattr() lookup.
+    anchor = _make_anchor(
+        ai_responses=[REMEMBER_RESPONSE, REMEMBER_RESPONSE],
+        light_ai_responses=["q1"],
+    )
+    anchor.MAX_REMEMBERS = 1
+
+    result = anchor.run("question")
+
+    assert result.stop_reason == "max_remembers"
+
+
+@pytest.mark.unit
+def test_guard_respects_subclass_level_max_remembers_override() -> None:
+    # Overriding the class attribute on a subclass must also be honored, so
+    # library users can configure the limit declaratively without mutating
+    # individual instances.
+    class TightAnchor(Anchor):
+        MAX_REMEMBERS = 1
+
+    anchor = TightAnchor(
+        ai_fn=scripted_model(REMEMBER_RESPONSE, REMEMBER_RESPONSE),
+        light_ai_fn=scripted_model("q1"),
+    )
+
+    result = anchor.run("question")
+
+    assert result.stop_reason == "max_remembers"


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary

<!-- REQUIRED -->
Adds deterministic tests for the `MAX_REMEMBERS` guard in `Loop.run()`, covering guard triggering, terminal marker stripping, boundary behavior, and custom limit overrides.

## Linked context

<!-- REQUIRED -->
<!-- Keep this heading name: automation reads it -->
Closes #12 

## PR Size

<!-- REQUIRED: check one -->

- [x] Small (< 100 LOC delta)
- [ ] Medium (100-499 LOC delta)
- [ ] Large (500-999 LOC delta)
- [ ] XL (1000+ LOC delta — must have been pre-discussed in an issue)

## PR Type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Prompt change (`prompt` label required; eval results required below)
- [x] Test
- [ ] Docs
- [ ] Refactor / chore

## Context / Motivation

<!-- REQUIRED -->
`Loop.run()` stops repeated `REMEMBER` cycles once the configured limit is exceeded. Since that guard is part of the public runtime behavior exposed through `Anchor.run()`, it should have explicit deterministic coverage.

## Changes

<!-- REQUIRED -->
Added `tests/unit/test_loop_max_remembers.py` with deterministic tests covering:
- repeated `REMEMBER` responses until the guard triggers
- `kind="done"` and `stop_reason="max_remembers"`
- removal of the trailing `REMEMBER` marker from returned content
- custom `MAX_REMEMBERS` values on the instance and subclass

## How to test

1. `uv run pytest -m "not eval" tests/unit/test_loop_max_remembers.py -v`
2. `uv run pytest -m "not eval"`
3. `uv run pre-commit run --all-files`

## Prompt Change Eval Results

<!-- Required if PR Type includes "Prompt change"; skip otherwise -->
<!-- Run: uv run pytest -m eval tests/evals -->
<!-- Preferred model: llama3:8b via Ollama -->

<details>
<summary>Full eval output (optional)</summary>

```text
<paste here>
```

</details>

## Checklist

- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers

Tests are deterministic, offline, and scoped specifically to the remember-limit guard behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for loop guard protection mechanisms, including validation of guard termination thresholds and override configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->