### PR TITLE
feat: populate RunResult metadata field in Loop.run

### DIFF
--- a/src/anchor/loop.py
+++ b/src/anchor/loop.py
@@ -28,8 +28,15 @@ class Loop:
     def run(self, query: str) -> RunResult:
         max_remembers = getattr(self.anchor, "MAX_REMEMBERS", 10)
         remembers = 0
-        retrieved_items = []
+        retrieved_items: list[dict] = []
         all_decomposed_queries: list[str] = []
+
+        def _metadata() -> dict[str, object]:
+            return {
+                "remember_count": remembers,
+                "decomposed_queries": list(all_decomposed_queries),
+                "retrieval_scores": [c["score"] for c in retrieved_items],
+            }
 
         messages = [
             {"role": "system", "content": self.anchor.system_prompt()},
@@ -76,11 +83,7 @@ class Loop:
                     content=final,
                     stop_reason="done",
                     retrieved_items=retrieved_items,
-                    metadata={
-                        "remember_count": remembers,
-                        "decomposed_queries": list(all_decomposed_queries),
-                        "retrieval_scores": [c["score"] for c in retrieved_items],
-                    },
+                    metadata=_metadata(),
                 )
 
             elif content.endswith(self.anchor.REMEMBER_MARKER):
@@ -93,11 +96,7 @@ class Loop:
                         ),
                         stop_reason="max_remembers",
                         retrieved_items=retrieved_items,
-                        metadata={
-                            "remember_count": remembers,
-                            "decomposed_queries": list(all_decomposed_queries),
-                            "retrieval_scores": [c["score"] for c in retrieved_items],
-                        },
+                        metadata=_metadata(),
                     )
 
                 gap, context = self._extract_gap(content)
@@ -135,11 +134,7 @@ class Loop:
                     content=self._strip_marker(content, self.anchor.CLARIFY_MARKER),
                     stop_reason="ask",
                     retrieved_items=retrieved_items,
-                    metadata={
-                        "remember_count": remembers,
-                        "decomposed_queries": list(all_decomposed_queries),
-                        "retrieval_scores": [c["score"] for c in retrieved_items],
-                    },
+                    metadata=_metadata(),
                 )
 
             else:
@@ -148,9 +143,5 @@ class Loop:
                     content=content,
                     stop_reason="error",
                     retrieved_items=retrieved_items,
-                    metadata={
-                        "remember_count": remembers,
-                        "decomposed_queries": list(all_decomposed_queries),
-                        "retrieval_scores": [c["score"] for c in retrieved_items],
-                    },
+                    metadata=_metadata(),
                 )

--- a/src/anchor/loop.py
+++ b/src/anchor/loop.py
@@ -29,6 +29,7 @@ class Loop:
         max_remembers = getattr(self.anchor, "MAX_REMEMBERS", 10)
         remembers = 0
         retrieved_items = []
+        all_decomposed_queries: list[str] = []
 
         messages = [
             {"role": "system", "content": self.anchor.system_prompt()},
@@ -40,6 +41,7 @@ class Loop:
             proactive_queries = self.anchor.decompose(
                 query, context=query, retrieved=None, history=messages[1:]
             )
+            all_decomposed_queries.extend(proactive_queries)
             seen_ids = set()
             proactive_chunks = []
             for q in proactive_queries:
@@ -74,6 +76,11 @@ class Loop:
                     content=final,
                     stop_reason="done",
                     retrieved_items=retrieved_items,
+                    metadata={
+                        "remember_count": remembers,
+                        "decomposed_queries": list(all_decomposed_queries),
+                        "retrieval_scores": [c["score"] for c in retrieved_items],
+                    },
                 )
 
             elif content.endswith(self.anchor.REMEMBER_MARKER):
@@ -86,6 +93,11 @@ class Loop:
                         ),
                         stop_reason="max_remembers",
                         retrieved_items=retrieved_items,
+                        metadata={
+                            "remember_count": remembers,
+                            "decomposed_queries": list(all_decomposed_queries),
+                            "retrieval_scores": [c["score"] for c in retrieved_items],
+                        },
                     )
 
                 gap, context = self._extract_gap(content)
@@ -96,6 +108,7 @@ class Loop:
                     retrieved=retrieved_items,
                     history=messages[1:],
                 )
+                all_decomposed_queries.extend(queries)
 
                 chunks = []
                 if self.anchor.retriever:
@@ -122,6 +135,11 @@ class Loop:
                     content=self._strip_marker(content, self.anchor.CLARIFY_MARKER),
                     stop_reason="ask",
                     retrieved_items=retrieved_items,
+                    metadata={
+                        "remember_count": remembers,
+                        "decomposed_queries": list(all_decomposed_queries),
+                        "retrieval_scores": [c["score"] for c in retrieved_items],
+                    },
                 )
 
             else:
@@ -130,4 +148,9 @@ class Loop:
                     content=content,
                     stop_reason="error",
                     retrieved_items=retrieved_items,
+                    metadata={
+                        "remember_count": remembers,
+                        "decomposed_queries": list(all_decomposed_queries),
+                        "retrieval_scores": [c["score"] for c in retrieved_items],
+                    },
                 )

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -23,6 +23,9 @@ def test_done_on_first_call() -> None:
     assert result.kind == "done"
     assert result.stop_reason == "done"
     assert result.content == "The answer is 42."
+    assert result.metadata["remember_count"] == 0
+    assert result.metadata["decomposed_queries"] == []
+    assert result.metadata["retrieval_scores"] == []
 
 
 @pytest.mark.unit
@@ -38,6 +41,9 @@ def test_single_remember_then_done() -> None:
     assert result.kind == "done"
     assert result.stop_reason == "done"
     assert result.content == "The answer is X."
+    assert result.metadata["remember_count"] == 1
+    assert result.metadata["decomposed_queries"] == ["what is X?", "query about X"]
+    assert result.metadata["retrieval_scores"] == []
 
 
 @pytest.mark.unit
@@ -54,6 +60,14 @@ def test_two_remembers_then_done() -> None:
     assert result.kind == "done"
     assert result.stop_reason == "done"
     assert result.content == "The final answer."
+    assert result.metadata["remember_count"] == 2
+    assert result.metadata["decomposed_queries"] == [
+        "what is X?",
+        "query about X",
+        "what is Y?",
+        "query about Y",
+    ]
+    assert result.metadata["retrieval_scores"] == []
 
 
 @pytest.mark.unit
@@ -63,6 +77,9 @@ def test_clarify_path() -> None:
     assert result.kind == "ask"
     assert result.stop_reason == "ask"
     assert "Which format do you want?" in result.content
+    assert result.metadata["remember_count"] == 0
+    assert result.metadata["decomposed_queries"] == []
+    assert result.metadata["retrieval_scores"] == []
 
 
 @pytest.mark.unit
@@ -72,6 +89,9 @@ def test_no_marker_error_path() -> None:
     result = anchor.run("What is this?")
     assert result.kind == "done"
     assert result.stop_reason == "error"
+    assert result.metadata["remember_count"] == 0
+    assert result.metadata["decomposed_queries"] == []
+    assert result.metadata["retrieval_scores"] == []
 
 
 @pytest.mark.unit
@@ -89,3 +109,8 @@ def test_max_remembers_guard() -> None:
     result = anchor.run("Something that requires many lookups.")
     assert result.kind == "done"
     assert result.stop_reason == "max_remembers"
+    # remembers increments to 3 before the early-exit check fires
+    assert result.metadata["remember_count"] == 3
+    # decompose is only called for cycles 1 and 2; cycle 3 exits before reaching decompose
+    assert result.metadata["decomposed_queries"] == ["gap1", "query1", "gap2", "query2"]
+    assert result.metadata["retrieval_scores"] == []


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Wires up the previously empty `metadata` field on `RunResult` by populating it across all four return paths in `Loop.run`. Callers can now inspect `remember_count`, `decomposed_queries`, and `retrieval_scores` for observability into each run.

## Linked context
Closes #36

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] New feature

## Context / Motivation
`RunResult.metadata` was typed as `dict[str, object]` but never written in the codebase. It was added to carry per-run observability data but left unwired, so this PR addresses that.

## Changes
- `src/anchor/loop.py`: added `all_decomposed_queries` accumulator, extended after each `decompose()` call (proactive pass and every REMEMBER cycle), and populated `metadata` on all four return paths (`done`, `ask`, `max_remembers`, `error`) with `remember_count`, `decomposed_queries`, and `retrieval_scores`
- `tests/unit/test_loop.py`: added exact `metadata` assertions to all 6 existing loop tests, covering expected query lists and scores per path

## How to test
1. `uv run pytest -m unit -v`
2. All 6 tests in `test_loop.py` should pass, now asserting metadata values in addition to existing checks

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
`remember_count` reflects the value of the internal `remembers` counter at exit, and on the `max_remembers` path this is `MAX_REMEMBERS + 1` because the counter increments before the guard check fires. The existing test asserts `remember_count == 3` with `MAX_REMEMBERS = 2`, which matches the current loop semantics, so if the guard is ever moved earlier, this value would change to `MAX_REMEMBERS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loop executions now include diagnostic metadata in results: remember_count, decomposed_queries (accumulated decomposition queries), and retrieval_scores across all termination paths.

* **Tests**
  * Added unit tests asserting diagnostic metadata correctness across scenarios: immediate completion, remember iterations, multiple remembers, clarification requests, protocol errors, and early termination (max remembers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->