### PR TITLE
test: add loop proactive retrieval integration tests

### DIFF
--- a/tests/unit/test_loop_proactive.py
+++ b/tests/unit/test_loop_proactive.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.anchor import Anchor
+from tests.unit_harness import FakeMemoryStore, scripted_model
+
+
+def _make_anchor_with_memory(
+    ai_responses: list[str],
+    light_ai_responses: list[str],
+    store: FakeMemoryStore,
+) -> tuple[Anchor, object, object]:
+    ai_model = scripted_model(*ai_responses)
+    light_model = scripted_model(*light_ai_responses)
+    anchor = Anchor(
+        ai_fn=ai_model,
+        light_ai_fn=light_model,
+        memory_store=store,
+        embed_fn=lambda _text: [0.0],
+    )
+    return anchor, ai_model, light_model
+
+
+@pytest.mark.unit
+def test_proactive_chunks_inject_memory_message() -> None:
+    """When the retriever returns chunks, a [MEMORY RETRIEVAL RESULT] message is
+    injected as the second user message before the first AI call."""
+    chunk = {"id": "c1", "content": "relevant fact", "source": "wiki", "score": 0.9}
+    store = FakeMemoryStore(query_results=[[chunk]])
+
+    # Light model drives decompose; returns the same text as the gap so it
+    # becomes the single proactive query (no extra insert by the decomposer).
+    anchor, ai_model, _light = _make_anchor_with_memory(
+        ai_responses=["The answer.\nDONE"],
+        light_ai_responses=["Tell me about X."],
+        store=store,
+    )
+    result = anchor.run("Tell me about X.")
+
+    first_call = ai_model.calls[0]
+    assert len(first_call) == 3, "expected system + user query + [MEMORY RETRIEVAL RESULT]"
+    assert first_call[1] == {"role": "user", "content": "Tell me about X."}
+    assert first_call[2]["role"] == "user"
+    assert "[MEMORY RETRIEVAL RESULT]" in first_call[2]["content"]
+
+    assert result.metadata["retrieval_scores"] == [0.9]
+    assert result.metadata["decomposed_queries"] == ["Tell me about X."]
+
+
+@pytest.mark.unit
+def test_proactive_no_chunks_no_message_injected() -> None:
+    """When the retriever returns no chunks, no memory retrieval message is
+    injected and the AI receives only the system prompt and user query."""
+    store = FakeMemoryStore(query_results=[[]])
+
+    anchor, ai_model, _light = _make_anchor_with_memory(
+        ai_responses=["The answer.\nDONE"],
+        light_ai_responses=["Tell me about X."],
+        store=store,
+    )
+    result = anchor.run("Tell me about X.")
+
+    first_call = ai_model.calls[0]
+    assert len(first_call) == 2, "expected only system + user query; no retrieval injection"
+    assert first_call[0]["role"] == "system"
+    assert first_call[1] == {"role": "user", "content": "Tell me about X."}
+
+    assert result.metadata["retrieval_scores"] == []
+    assert result.metadata["decomposed_queries"] == ["Tell me about X."]
+
+
+@pytest.mark.unit
+def test_proactive_skipped_when_no_retriever_configured() -> None:
+    """When Anchor is initialized without memory_store/embed_fn, proactive
+    retrieval is skipped entirely — the decomposer is never called and the AI
+    receives only the system prompt and user query."""
+    ai_model = scripted_model("The answer.\nDONE")
+    light_model = scripted_model()  # raises if called unexpectedly
+
+    anchor = Anchor(ai_fn=ai_model, light_ai_fn=light_model)
+    result = anchor.run("Tell me about X.")
+
+    first_call = ai_model.calls[0]
+    assert len(first_call) == 2, "expected only system + user query; no retrieval injection"
+    assert first_call[0]["role"] == "system"
+    assert first_call[1]["role"] == "user"
+
+    assert len(light_model.calls) == 0, "decomposer must not be called when no retriever"
+    assert result.metadata["decomposed_queries"] == []
+    assert result.metadata["retrieval_scores"] == []
+
+
+@pytest.mark.unit
+def test_proactive_chunk_ids_not_readded_during_remember() -> None:
+    """Chunk IDs fetched during proactive retrieval are tracked in seen_ids so
+    that if the same chunk is returned again during a REMEMBER pass it is not
+    added to retrieved_items a second time."""
+    chunk = {"id": "c1", "content": "fact about X", "source": "src", "score": 0.9}
+    # Two queued results: one for the proactive query, one for the REMEMBER query.
+    # Both return the same chunk to exercise the dedup logic.
+    store = FakeMemoryStore(query_results=[[chunk], [chunk]])
+
+    anchor, ai_model, _light = _make_anchor_with_memory(
+        ai_responses=[
+            "GAP: what is X?\nCONTEXT: investigating\nREMEMBER",
+            "Final answer.\nDONE",
+        ],
+        light_ai_responses=[
+            "Tell me about X.",  # proactive decompose: single query matching the gap
+            "what is X?",        # REMEMBER decompose: single query matching the gap
+        ],
+        store=store,
+    )
+    result = anchor.run("Tell me about X.")
+
+    assert result.metadata["remember_count"] == 1
+    assert len(result.retrieved_items) == 1, "duplicate chunk must not be added twice"
+    assert result.retrieved_items[0]["id"] == "c1"
+    assert result.metadata["retrieval_scores"] == [0.9]
+    assert result.metadata["decomposed_queries"] == ["Tell me about X.", "what is X?"]

--- a/tests/unit/test_loop_proactive.py
+++ b/tests/unit/test_loop_proactive.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import pytest
 
 from anchor.anchor import Anchor
-from tests.unit_harness import FakeMemoryStore, scripted_model
+from tests.unit_harness import FakeMemoryStore, ScriptedModel, scripted_model
 
 
 def _make_anchor_with_memory(
     ai_responses: list[str],
     light_ai_responses: list[str],
     store: FakeMemoryStore,
-) -> tuple[Anchor, object, object]:
+) -> tuple[Anchor, ScriptedModel, ScriptedModel]:
     ai_model = scripted_model(*ai_responses)
     light_model = scripted_model(*light_ai_responses)
     anchor = Anchor(
@@ -39,7 +39,9 @@ def test_proactive_chunks_inject_memory_message() -> None:
     result = anchor.run("Tell me about X.")
 
     first_call = ai_model.calls[0]
-    assert len(first_call) == 3, "expected system + user query + [MEMORY RETRIEVAL RESULT]"
+    assert (
+        len(first_call) == 3
+    ), "expected system + user query + [MEMORY RETRIEVAL RESULT]"
     assert first_call[1] == {"role": "user", "content": "Tell me about X."}
     assert first_call[2]["role"] == "user"
     assert "[MEMORY RETRIEVAL RESULT]" in first_call[2]["content"]
@@ -62,7 +64,9 @@ def test_proactive_no_chunks_no_message_injected() -> None:
     result = anchor.run("Tell me about X.")
 
     first_call = ai_model.calls[0]
-    assert len(first_call) == 2, "expected only system + user query; no retrieval injection"
+    assert (
+        len(first_call) == 2
+    ), "expected only system + user query; no retrieval injection"
     assert first_call[0]["role"] == "system"
     assert first_call[1] == {"role": "user", "content": "Tell me about X."}
 
@@ -82,11 +86,15 @@ def test_proactive_skipped_when_no_retriever_configured() -> None:
     result = anchor.run("Tell me about X.")
 
     first_call = ai_model.calls[0]
-    assert len(first_call) == 2, "expected only system + user query; no retrieval injection"
+    assert (
+        len(first_call) == 2
+    ), "expected only system + user query; no retrieval injection"
     assert first_call[0]["role"] == "system"
     assert first_call[1]["role"] == "user"
 
-    assert len(light_model.calls) == 0, "decomposer must not be called when no retriever"
+    assert (
+        len(light_model.calls) == 0
+    ), "decomposer must not be called when no retriever"
     assert result.metadata["decomposed_queries"] == []
     assert result.metadata["retrieval_scores"] == []
 
@@ -101,14 +109,14 @@ def test_proactive_chunk_ids_not_readded_during_remember() -> None:
     # Both return the same chunk to exercise the dedup logic.
     store = FakeMemoryStore(query_results=[[chunk], [chunk]])
 
-    anchor, ai_model, _light = _make_anchor_with_memory(
+    anchor, _ai_model, _light = _make_anchor_with_memory(
         ai_responses=[
             "GAP: what is X?\nCONTEXT: investigating\nREMEMBER",
             "Final answer.\nDONE",
         ],
         light_ai_responses=[
             "Tell me about X.",  # proactive decompose: single query matching the gap
-            "what is X?",        # REMEMBER decompose: single query matching the gap
+            "what is X?",  # REMEMBER decompose: single query matching the gap
         ],
         store=store,
     )


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Added deterministic offline tests for the proactive retrieval path in `Loop.run` (runs before the first AI call to decompose the query, retrieve chunks, and inject a `[MEMORY RETRIEVAL RESULT]` message). All existing loop tests used `Anchor` with no memory store, leaving this entire path untested.

## Linked context
Closes #35

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] Test

## Context / Motivation
The proactive retrieval path is the first process `Loop.run` executes and affects every conversation that has a memory store configured, but it did not have unit test coverage. `FakeMemoryStore` and `scripted_model` were already available to test it fully offline.

## Changes
Added `tests/unit/test_loop_proactive.py` with 4 tests:
- Chunks returned by retriever cause `[MEMORY RETRIEVAL RESULT]` injection as the second user message before first AI call
- Empty retriever results produce no injection; AI receives only system prompt and user query
- No retriever configured; proactive block skipped entirely and decomposer never called
- Chunk IDs fetched proactively enter `seen_ids`; same chunk returned during a REMEMBER pass is not added to `retrieved_items` a second time

## How to test
1. `uv run pytest -m unit -v`
2. All 4 tests in `test_loop_proactive.py` should pass; full unit suite (65 tests) passes with no regressions

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
The pip-audit hook fails in CI due to a CVE in pip itself. This is the same pre-existing false positive as other recent PRs. All other hooks pass cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for the proactive retrieval loop verifying message sequences sent to the assistant.
  * Validates metadata includes retrieval scores and decomposed queries when results exist, and empty scores when none.
  * Confirms retrieval is skipped when no memory backend is configured, and that deduplication prevents duplicate retrieved items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->