### PR TITLE
feat: add PersistentChromaMemoryStore and persistent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ If you only run deterministic tests (`-m "not eval"`), Ollama is optional.
 
 ## Quickstart
 
+Use `ChromaMemoryStore` for quick demos (in-memory) and `PersistentChromaMemoryStore` when memory should persist across restarts.
+
 ```bash
-# Run the default chat example
+# In-memory store (does NOT persist)
 uv run python examples/chat.py
+
+# Persistent store (recommended for real use)
+uv run python examples/persistent_chat.py
 ```
 
 ## Run examples

--- a/examples/persistent_chat.py
+++ b/examples/persistent_chat.py
@@ -1,0 +1,79 @@
+# examples/persistent_chat.py
+#
+# Recommended setup for real agent continuity use cases. This example uses
+# PersistentChromaMemoryStore so ingested chunks survive process restart -
+# point a new run at the same path to recover prior memory.
+#
+# When to use each store:
+#   - ChromaMemoryStore (in-memory): tests, quick demos, throwaway sessions
+#     where memory should NOT survive process restart.
+#   - PersistentChromaMemoryStore (on-disk): real deployments, long-running
+#     agents, and any case where ingested memory should persist across runs.
+import ollama as _ollama
+from anchor import Anchor
+from anchor.memory import PersistentChromaMemoryStore
+
+
+class OllamaFn:
+    def __init__(self, model: str):
+        self.model = model
+
+    def __call__(self, messages: list[dict]) -> str:
+        print("[OllamaFn] calling model...", flush=True)
+        response = _ollama.chat(model=self.model, messages=messages, think=False)
+        print("[OllamaFn] got response: " + response.message.content, flush=True)
+        return response.message.content
+
+
+class OllamaEmbedFn:
+    def __init__(self, model: str = "bge-m3"):
+        self.model = model
+
+    def __call__(self, text: str) -> list[float]:
+        return _ollama.embeddings(model=self.model, prompt=text).embedding
+
+
+SEED_CHUNKS = [
+    ("The project codename is ORCHID-7.", "seed"),
+    ("The max retry limit is 7 for standard tenants.", "seed"),
+    ("Severity levels are SABLE, BRASS, and IVORY in descending order.", "seed"),
+    ("The release train KITE-DELTA ships on Thursdays at 19:40 UTC.", "seed"),
+    ("Tenant COBALT has a payout holdback of 4 percent.", "seed"),
+]
+
+
+def main():
+    ai = OllamaFn("qwen3:1.7b")
+    light_ai = OllamaFn("qwen3:1.7b")
+    embed_fn = OllamaEmbedFn()
+
+    # Memory persists at this path across process restarts.
+    memory_store = PersistentChromaMemoryStore(path=".anchor/memory")
+
+    anchor = Anchor(
+        ai_fn=ai,
+        light_ai_fn=light_ai,
+        memory_store=memory_store,
+        embed_fn=embed_fn,
+    )
+
+    print("Ingesting seed chunks...")
+    for text, source in SEED_CHUNKS:
+        chunk_id = anchor.ingest_text(text, source=source)
+        print(f"  ingested [{source}]: {text[:60]} -> {chunk_id}")
+    print()
+
+    print("Chat with Anchor. Type 'exit' to quit.\n")
+    while True:
+        query = input("You> ").strip()
+        if not query or query.lower() == "exit":
+            break
+        result = anchor.run(query)
+        print(f"Anchor> {result.content}")
+        if result.stop_reason != "done":
+            print(f"  [stop_reason: {result.stop_reason}]")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/persistent_chat.py
+++ b/examples/persistent_chat.py
@@ -9,9 +9,9 @@
 #     where memory should NOT survive process restart.
 #   - PersistentChromaMemoryStore (on-disk): real deployments, long-running
 #     agents, and any case where ingested memory should persist across runs.
+from pathlib import Path
 import ollama as _ollama
-from anchor import Anchor
-from anchor.memory import PersistentChromaMemoryStore
+from anchor import Anchor, PersistentChromaMemoryStore
 
 
 class OllamaFn:
@@ -41,6 +41,9 @@ SEED_CHUNKS = [
     ("Tenant COBALT has a payout holdback of 4 percent.", "seed"),
 ]
 
+MEMORY_PATH = Path(".anchor/memory")
+SEED_MARKER = MEMORY_PATH / ".persistent_chat_seeded_v1"
+
 
 def main():
     ai = OllamaFn("qwen3:1.7b")
@@ -48,7 +51,7 @@ def main():
     embed_fn = OllamaEmbedFn()
 
     # Memory persists at this path across process restarts.
-    memory_store = PersistentChromaMemoryStore(path=".anchor/memory")
+    memory_store = PersistentChromaMemoryStore(path=str(MEMORY_PATH))
 
     anchor = Anchor(
         ai_fn=ai,
@@ -57,15 +60,25 @@ def main():
         embed_fn=embed_fn,
     )
 
-    print("Ingesting seed chunks...")
-    for text, source in SEED_CHUNKS:
-        chunk_id = anchor.ingest_text(text, source=source)
-        print(f"  ingested [{source}]: {text[:60]} -> {chunk_id}")
-    print()
+    if not SEED_MARKER.exists():
+        print("Ingesting seed chunks...")
+        for text, source in SEED_CHUNKS:
+            chunk_id = anchor.ingest_text(text, source=source)
+            print(f"  ingested [{source}]: {text[:60]} -> {chunk_id}")
+
+        SEED_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        SEED_MARKER.write_text("ok\n", encoding="utf-8")
+        print()
+    else:
+        print("Seed chunks already present; skipping ingest.\n")
 
     print("Chat with Anchor. Type 'exit' to quit.\n")
     while True:
-        query = input("You> ").strip()
+        try:
+            query = input("You> ").strip()
+        except EOFError:
+            print()
+            break
         if not query or query.lower() == "exit":
             break
         result = anchor.run(query)

--- a/src/anchor/__init__.py
+++ b/src/anchor/__init__.py
@@ -1,6 +1,14 @@
 from anchor.anchorfn import AnchorFn
 from anchor.anchor import Anchor
 from anchor.config import AnchorConfig
+from anchor.memory import ChromaMemoryStore, PersistentChromaMemoryStore
 from anchor.runresult import RunResult
 
-__all__ = ["Anchor", "AnchorConfig", "AnchorFn", "RunResult"]
+__all__ = [
+    "Anchor",
+    "AnchorConfig",
+    "AnchorFn",
+    "ChromaMemoryStore",
+    "PersistentChromaMemoryStore",
+    "RunResult",
+]

--- a/src/anchor/memory.py
+++ b/src/anchor/memory.py
@@ -98,3 +98,13 @@ class ChromaMemoryStore(MemoryStore):
             "content": docs[0] if docs else "",
             "metadata": metas[0] if metas else {},
         }
+
+
+class PersistentChromaMemoryStore(ChromaMemoryStore):
+    """Persistent ChromaDB implementation of MemoryStore."""
+
+    def __init__(self, path: str, collection_name: str = "anchor"):
+        import chromadb
+
+        self.chroma = chromadb.PersistentClient(path=path)
+        self.collection = self.chroma.get_or_create_collection(collection_name)


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary

<!-- REQUIRED -->
Adds a persistent Chroma-backed memory store (`PersistentChromaMemoryStore`) that allows ingested memory to survive process restarts. Also includes a new example demonstrating persistent usage and updates the README Quickstart to show both in-memory and persistent options.

## Linked context

<!-- REQUIRED -->
<!-- Keep this heading name: automation reads it -->
Closes #37

## PR Size

<!-- REQUIRED: check one -->

- [x] Small (< 100 LOC delta)
- [ ] Medium (100-499 LOC delta)
- [ ] Large (500-999 LOC delta)
- [ ] XL (1000+ LOC delta — must have been pre-discussed in an issue)

## PR Type

<!-- Check all that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Prompt change (`prompt` label required; eval results required below)
- [ ] Test
- [ ] Docs
- [ ] Refactor / chore

## Context / Motivation

<!-- REQUIRED -->
`ChromaMemoryStore` currently uses an in-memory client, which does not persist data across process restarts. The roadmap recommends persistent storage for real deployments, but no such option existed. This change introduces a persistent alternative while keeping the existing in-memory store unchanged.

## Changes

<!-- REQUIRED -->
- Added `PersistentChromaMemoryStore` using `chromadb.PersistentClient`
- Exported `PersistentChromaMemoryStore` from the top-level package
- Added `examples/persistent_chat.py` demonstrating persistent memory usage
- Updated README Quickstart to show both in-memory and persistent options
## How to test

1. Run deterministic tests:

   ```bash
   uv run pytest -m "not eval"
   ```

2. Run the persistent example:

   ```bash
   uv run python examples/persistent_chat.py
   ```

3. Restart the process and verify memory persists when using the same path.

## Prompt Change Eval Results

<!-- Required if PR Type includes "Prompt change"; skip otherwise -->
<!-- Run: uv run pytest -m eval tests/evals -->
<!-- Preferred model: llama3:8b via Ollama -->

<details>
<summary>Full eval output (optional)</summary>

```text
<paste here>
```

</details>

## Checklist

- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers

This implementation uses inheritance from `ChromaMemoryStore` to avoid duplicating logic while keeping the interface identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent on-disk memory store so app memory can be retained across restarts.
  * Public API now exposes both in-memory and persistent memory store options.

* **Documentation**
  * Quickstart updated to show when to use in-memory vs persistent stores and added example commands.

* **Examples**
  * Added a new persistent chat example demonstrating persistent memory usage and one-time seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->