### PR TITLE
test: add synthesizer deterministic contract tests

### DIFF
--- a/tests/unit/test_synthesizer.py
+++ b/tests/unit/test_synthesizer.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.synthesizer import Synthesizer
+
+
+def _spy_model(response: str = "synthesized answer"):
+    """Returns (model_fn, calls). Each call appends the user-role prompt text."""
+    calls: list[str] = []
+
+    def model_fn(messages: list[dict]) -> str:
+        calls.append(messages[0]["content"])
+        return response
+
+    return model_fn, calls
+
+
+@pytest.mark.unit
+def test_empty_chunks_returns_fallback_without_calling_model() -> None:
+    model_fn, calls = _spy_model()
+    result = Synthesizer(model_fn).synthesize([])
+    assert result == "No relevant information found in memory."
+    assert calls == []
+
+
+@pytest.mark.unit
+def test_single_chunk_returns_formatted_content_without_calling_model() -> None:
+    model_fn, calls = _spy_model()
+    chunk = {"source": "doc_A", "content": "The sky is blue."}
+    result = Synthesizer(model_fn).synthesize([chunk])
+    assert result == "[Source: doc_A]\nThe sky is blue."
+    assert calls == []
+
+
+@pytest.mark.unit
+def test_multi_chunk_with_questions_prompt_contains_chunk_content_and_sources() -> None:
+    model_fn, calls = _spy_model()
+    chunks = [
+        {"source": "src_1", "content": "fact one"},
+        {"source": "src_2", "content": "fact two"},
+    ]
+    Synthesizer(model_fn).synthesize(chunks, questions=["What is X?"])
+    assert len(calls) == 1
+    prompt = calls[0]
+    assert "fact one" in prompt
+    assert "fact two" in prompt
+    assert "[Source: src_1]" in prompt
+    assert "[Source: src_2]" in prompt
+
+
+@pytest.mark.unit
+def test_multi_chunk_with_single_question_marks_it_current() -> None:
+    model_fn, calls = _spy_model()
+    chunks = [
+        {"source": "s1", "content": "alpha"},
+        {"source": "s2", "content": "beta"},
+    ]
+    Synthesizer(model_fn).synthesize(chunks, questions=["Tell me about alpha"])
+    assert "Tell me about alpha (current)" in calls[0]
+
+
+@pytest.mark.unit
+def test_multi_chunk_with_multiple_questions_only_last_is_marked_current() -> None:
+    model_fn, calls = _spy_model()
+    chunks = [
+        {"source": "s1", "content": "alpha"},
+        {"source": "s2", "content": "beta"},
+    ]
+    questions = ["First question", "Second question", "Third question"]
+    Synthesizer(model_fn).synthesize(chunks, questions=questions)
+    prompt = calls[0]
+    assert "- Third question (current)" in prompt
+    assert "- First question\n" in prompt
+    assert "- Second question\n" in prompt
+    assert "First question (current)" not in prompt
+    assert "Second question (current)" not in prompt
+
+
+@pytest.mark.unit
+def test_multi_chunk_without_questions_prompt_contains_chunk_content_and_sources() -> None:
+    model_fn, calls = _spy_model()
+    chunks = [
+        {"source": "src_A", "content": "content alpha"},
+        {"source": "src_B", "content": "content beta"},
+    ]
+    Synthesizer(model_fn).synthesize(chunks)
+    assert len(calls) == 1
+    prompt = calls[0]
+    assert "content alpha" in prompt
+    assert "content beta" in prompt
+    assert "[Source: src_A]" in prompt
+    assert "[Source: src_B]" in prompt


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds deterministic offline tests for all three branches of `Synthesizer.synthesize()`: empty chunks, single-chunk fast path, and multi-chunk prompt construction. Verifies the model is never called for the first two paths and that prompt content, source labels, and `(current)` question marking are correct for the multi-chunk path.

## Linked context
Closes #18

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] Test

## Context / Motivation
`Synthesizer` had no unit tests despite having three distinct code paths with specific output contracts. This PR pins those contracts so future changes to synthesis logic have a regression baseline.

## Changes
Added `tests/unit/test_synthesizer.py` with 6 tests:
- Empty chunk list returns fallback string, model never called
- Single chunk returns formatted content directly, model never called
- Multi-chunk with questions — prompt includes chunk content and `[Source: X]` labels
- Single question in multi-chunk case is marked `(current)`
- Multiple questions in multi-chunk case — only the final one is marked `(current)`, others are plain
- Multi-chunk without questions — prompt still includes chunk content and source labels

## How to test
1. `uv run pytest -m unit -v`
2. All 6 tests in `test_synthesizer.py` should pass with no network or Ollama dependency

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
The `_spy_model` helper follows the same pattern as `test_decomposer_prompts.py`, in that it captures `messages[0]["content"]` so assertions read against real prompt text. The single-chunk fast path test asserts the model is never called, which essentially documents the existing short-circuit behaviour and catches any future accidental removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for synthesizer functionality to ensure reliability across various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->