### PR TITLE
test: add synthesizer prompt eval

### DIFF
--- a/tests/evals/test_eval_synthesizer.py
+++ b/tests/evals/test_eval_synthesizer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.synthesizer import Synthesizer
+
+
+# Three chunks with overlapping entities (Elena Marsh, NovaTech) and complementary
+# facts (founding/HQ, product details, founder background).
+CHUNKS = [
+    {
+        "source": "company_overview",
+        "content": (
+            "Elena Marsh founded NovaTech in 2018. "
+            "The company is headquartered in Austin, Texas."
+        ),
+    },
+    {
+        "source": "product_brief",
+        "content": (
+            "NovaTech's flagship product is Prism, a platform that processes "
+            "satellite imagery for agricultural monitoring. Prism launched in 2020."
+        ),
+    },
+    {
+        "source": "founder_bio",
+        "content": (
+            "Elena Marsh holds a PhD in remote sensing from Stanford University "
+            "and has over 15 years of experience in the geospatial industry."
+        ),
+    },
+]
+
+# Two-question context so the (current) marker lands on the second question.
+QUESTIONS = [
+    "What companies use satellite imagery?",
+    "Who founded NovaTech and what does their main product do?",
+]
+
+_REFUSAL_PHRASES = ("i cannot", "i can't", "i'm unable", "no information")
+
+# Entities that appear nowhere in the chunks above.
+_ABSENT_ENTITIES = ("Tesla", "Elon Musk", "Python", "OpenAI", "Microsoft")
+
+
+@pytest.mark.eval
+@pytest.mark.parametrize("run_number", range(5))
+def test_eval_synthesizer_synthesize(ai_fn, run_number):
+    synthesizer = Synthesizer(model_fn=ai_fn)
+    output = synthesizer.synthesize(CHUNKS, QUESTIONS)
+
+    # Not empty or a refusal.
+    assert output and output.strip(), f"[run {run_number}] output was empty"
+    assert not any(p in output.lower() for p in _REFUSAL_PHRASES), (
+        f"[run {run_number}] output looks like a refusal: {output!r}"
+    )
+
+    # Key facts spanning all three chunks must appear in the synthesis.
+    for fact in ("Elena Marsh", "NovaTech", "Prism", "satellite"):
+        assert fact.lower() in output.lower(), (
+            f"[run {run_number}] missing expected fact {fact!r}: {output!r}"
+        )
+
+    # Current question asks about the founder — must be addressed.
+    assert "elena" in output.lower() or "founder" in output.lower(), (
+        f"[run {run_number}] founder topic not addressed: {output!r}"
+    )
+
+    # Current question asks about the main product — must be addressed.
+    assert "prism" in output.lower() or "satellite" in output.lower(), (
+        f"[run {run_number}] product topic not addressed: {output!r}"
+    )
+
+    # Model must not hallucinate entities absent from the input chunks.
+    for entity in _ABSENT_ENTITIES:
+        assert entity.lower() not in output.lower(), (
+            f"[run {run_number}] hallucinated entity {entity!r}: {output!r}"
+        )


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds a live eval verifying that `Synthesizer.synthesize` produces a coherent, grounded synthesis from multiple retrieved chunks using a real Ollama model. Parameterized 5x to catch flakiness from non-deterministic LLM output.

## Linked context
Closes #33

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] Test

## Context / Motivation
The deterministic contract tests for `Synthesizer` (issue #18) verify prompt structure and the single-chunk fast path, but no eval verified that a real model actually produces a coherent, grounded synthesis from that prompt. This PR adds that coverage.

## Changes
Added `tests/evals/test_eval_synthesizer.py` with one eval test parameterized 5x:
- Seeds 3 chunks with overlapping entities (Elena Marsh, NovaTech) and complementary facts (founding/HQ, product details, founder background)
- Calls `synthesizer.synthesize(chunks, questions)` directly with the real `ai_fn` fixture; no ChromaMemoryStore needed since the synthesizer takes raw chunk lists
- Two questions passed so the `(current)` marker lands on the second question, exercising that prompt branch
- Asserts: output is non-empty and not a refusal, key facts from chunks appear in output, absent entities are not hallucinated, the current question's topic is addressed

## How to test
1. Requires Ollama running locally with `qwen3:4b-instruct` pulled (`ollama pull qwen3:4b-instruct`)
2. `uv run pytest -m eval tests/evals/test_eval_synthesizer.py -v`

## Prompt Change Eval Results


Full eval output (optional)


## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
No `ChromaMemoryStore` is used, as `synthesize()` takes raw `list[dict]` chunks directly, so seeding into a store and retrieving would add noise without testing anything about the synthesizer itself. The absent-entity assertion checks a fixed list (`Tesla`, `Elon Musk`, `Python`, `OpenAI`, `Microsoft`); if the model hallucinates a different entity not in this list, that case would go undetected, but the fact and topic assertions provide complementary coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation testing for the Synthesizer to ensure synthesis output accuracy, verify relevant information is included, and prevent hallucinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->