### PR TITLE
test: add decomposer prompt eval

### DIFF
--- a/tests/evals/test_eval_decomposer.py
+++ b/tests/evals/test_eval_decomposer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from anchor.decomposer import Decomposer
@@ -25,8 +27,13 @@ _RETRIEVED = [
     },
 ]
 
-# Named entities absent from _GAP, _CONTEXT, and _RETRIEVED.
-_ABSENT_ENTITIES = ("Falcon-9", "Starlink", "SpaceX", "Tesla", "Crew Dragon")
+
+def _named_tokens(text: str) -> set[str]:
+    """Return lowercased capitalized tokens (≥2 chars) as named-entity proxies."""
+    return {
+        m.group().lower()
+        for m in re.finditer(r"\b[A-Z][A-Za-z0-9]+(?:-[A-Za-z0-9]+)*\b", text)
+    }
 
 
 @pytest.mark.eval
@@ -35,16 +42,18 @@ def test_eval_decomposer_no_retrieval(light_ai_fn, run_number):
     decomposer = Decomposer(model_fn=light_ai_fn)
     queries = decomposer.decompose(_GAP)
 
-    assert len(queries) >= 2, (
-        f"[run {run_number}] expected at least 2 queries, got {len(queries)}: {queries!r}"
-    )
-    assert queries[0] == _GAP, (
-        f"[run {run_number}] gap must be first query, got {queries[0]!r}"
-    )
-    for entity in _ABSENT_ENTITIES:
-        for q in queries:
-            assert entity.lower() not in q.lower(), (
-                f"[run {run_number}] query references absent entity {entity!r}: {q!r}"
+    assert (
+        len(queries) >= 2
+    ), f"[run {run_number}] expected at least 2 queries, got {len(queries)}: {queries!r}"
+    assert (
+        queries[0] == _GAP
+    ), f"[run {run_number}] gap must be first query, got {queries[0]!r}"
+    allowed_text = _GAP.lower()
+    for q in queries:
+        for entity in _named_tokens(q):
+            assert entity in allowed_text, (
+                f"[run {run_number}] query {q!r} contains entity {entity!r} "
+                f"not present in gap {_GAP!r}"
             )
 
 
@@ -61,15 +70,24 @@ def test_eval_decomposer_retrieval_aware(light_ai_fn, run_number):
         f"nr={nr_queries!r} ra={ra_queries!r}"
     )
 
-    for entity in _ABSENT_ENTITIES:
-        for q in ra_queries:
-            assert entity.lower() not in q.lower(), (
-                f"[run {run_number}] retrieval-aware query references absent entity "
-                f"{entity!r}: {q!r}"
+    allowed_text = " ".join(
+        [
+            _GAP,
+            _CONTEXT,
+            *[r["content"] for r in _RETRIEVED],
+            *[r["questions"] for r in _RETRIEVED],
+        ]
+    ).lower()
+    for q in ra_queries:
+        for entity in _named_tokens(q):
+            assert entity in allowed_text, (
+                f"[run {run_number}] retrieval-aware query {q!r} contains entity "
+                f"{entity!r} not present in gap, context, or retrieved entries"
             )
 
-    retrieved_contents = {r["content"].lower() for r in _RETRIEVED}
+    retrieved_contents = [r["content"].lower() for r in _RETRIEVED]
     for q in ra_queries:
-        assert q.lower() not in retrieved_contents, (
-            f"[run {run_number}] query duplicates a retrieved fact verbatim: {q!r}"
+        assert not any(q.lower() in content for content in retrieved_contents), (
+            f"[run {run_number}] query {q!r} is a substring of a retrieved fact: "
+            f"ra_queries={ra_queries!r} retrieved_contents={retrieved_contents!r}"
         )

--- a/tests/evals/test_eval_decomposer.py
+++ b/tests/evals/test_eval_decomposer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.decomposer import Decomposer
+
+
+_GAP = "What is the maximum data transfer rate of the Orion-5 satellite uplink?"
+
+_CONTEXT = (
+    "Helios Corp operates the Orion-5 satellite for government clients. "
+    "The mission requires a high-bandwidth uplink with AES-256 encryption."
+)
+
+_RETRIEVED = [
+    {
+        "id": "ret-1",
+        "questions": "What encryption does the Orion-5 uplink use?",
+        "content": "Orion-5 uplink uses AES-256 encryption as mandated by Helios Corp.",
+    },
+    {
+        "id": "ret-2",
+        "questions": "Who operates the Orion-5 satellite?",
+        "content": "Helios Corp operates the Orion-5 satellite on behalf of government clients.",
+    },
+]
+
+# Named entities absent from _GAP, _CONTEXT, and _RETRIEVED.
+_ABSENT_ENTITIES = ("Falcon-9", "Starlink", "SpaceX", "Tesla", "Crew Dragon")
+
+
+@pytest.mark.eval
+@pytest.mark.parametrize("run_number", range(5))
+def test_eval_decomposer_no_retrieval(light_ai_fn, run_number):
+    decomposer = Decomposer(model_fn=light_ai_fn)
+    queries = decomposer.decompose(_GAP)
+
+    assert len(queries) >= 2, (
+        f"[run {run_number}] expected at least 2 queries, got {len(queries)}: {queries!r}"
+    )
+    assert queries[0] == _GAP, (
+        f"[run {run_number}] gap must be first query, got {queries[0]!r}"
+    )
+    for entity in _ABSENT_ENTITIES:
+        for q in queries:
+            assert entity.lower() not in q.lower(), (
+                f"[run {run_number}] query references absent entity {entity!r}: {q!r}"
+            )
+
+
+@pytest.mark.eval
+@pytest.mark.parametrize("run_number", range(5))
+def test_eval_decomposer_retrieval_aware(light_ai_fn, run_number):
+    decomposer = Decomposer(model_fn=light_ai_fn)
+
+    nr_queries = decomposer.decompose(_GAP)
+    ra_queries = decomposer.decompose(_GAP, context=_CONTEXT, retrieved=_RETRIEVED)
+
+    assert nr_queries != ra_queries, (
+        f"[run {run_number}] retrieval-aware queries should differ from no-retrieval: "
+        f"nr={nr_queries!r} ra={ra_queries!r}"
+    )
+
+    for entity in _ABSENT_ENTITIES:
+        for q in ra_queries:
+            assert entity.lower() not in q.lower(), (
+                f"[run {run_number}] retrieval-aware query references absent entity "
+                f"{entity!r}: {q!r}"
+            )
+
+    retrieved_contents = {r["content"].lower() for r in _RETRIEVED}
+    for q in ra_queries:
+        assert q.lower() not in retrieved_contents, (
+            f"[run {run_number}] query duplicates a retrieved fact verbatim: {q!r}"
+        )


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds live eval tests for both prompt paths in `Decomposer.decompose` using a real Ollama model. Covers the no-retrieval path and the retrieval-aware path, each parameterized 5x to catch flakiness.

## Linked context
Closes #34

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] Test

## Context / Motivation
The deterministic tests for `Decomposer` (#14, #15) verify prompt construction and output normalization, but no eval verified that a real model produces grounded, useful queries from those prompts. This PR adds that coverage for both prompt paths.

## Changes
Added `tests/evals/test_eval_decomposer.py` with two eval tests each parameterized 5x:
- `test_eval_decomposer_no_retrieval` - calls `decompose(gap)` with no context; asserts gap is first query, at least 2 queries returned, and no absent entities hallucinated
- `test_eval_decomposer_retrieval_aware` - calls `decompose(gap, context=..., retrieved=[...])` with a populated retrieved list; asserts queries differ from the no-retrieval path, no absent entities, and queries do not duplicate facts already present in retrieved entries

## How to test
1. Requires Ollama running locally with `qwen3:0.6b` pulled (`ollama pull qwen3:0.6b`)
2. `uv run pytest -m eval tests/evals/test_eval_decomposer.py -v`

## Prompt Change Eval Results


Full eval output (optional)


## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
Test data uses a domain-specific gap (Orion-5 satellite uplink) with named entities unlikely to be hallucinated by a small model. Absent entities (`Falcon-9`, `Starlink`, `SpaceX`, etc.) are plausible-but-wrong entities from a similar domain. The "differ" assertion between the two paths calls both `decompose(gap)` and `decompose(gap, context=..., retrieved=...)` within the same test run and compares the returned query sets; identical output from both paths would indicate the retrieval-aware prompt steering is not working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive evaluation tests for decomposer query generation to ensure proper query output, entity exclusion, and retrieval-aware behavior validation without content duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->