### PR TITLE
test: add CLARIFY protocol path eval

### DIFF
--- a/tests/evals/test_eval_clarify.py
+++ b/tests/evals/test_eval_clarify.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor import Anchor
+
+
+# Queries that are genuinely underspecified: no entity names, no clear intent,
+# no recoverable context.  The model has no choice but to ask for clarification.
+UNDERSPECIFIED_QUERIES = [
+    "help me with it",
+    "what about the other one",
+    "fix this",
+]
+
+
+@pytest.fixture
+def anchor(ai_fn, light_ai_fn):
+    # No memory store — retrieval is irrelevant for intent-clarification evals.
+    return Anchor(ai_fn=ai_fn, light_ai_fn=light_ai_fn)
+
+
+# NOTE: The model may currently fail these tests if the system prompt needs
+# fine-tuning to reliably route to CLARIFY (unclear intent) rather than
+# REMEMBER (missing entity/fact) for maximally vague inputs.
+# The assertions below are correct per spec; the prompt is the variable.
+@pytest.mark.eval
+@pytest.mark.parametrize("run_number", range(3))
+@pytest.mark.parametrize("query", UNDERSPECIFIED_QUERIES)
+def test_eval_clarify(anchor, query, run_number):
+    result = anchor.run(query)
+
+    assert result.stop_reason == "ask", (
+        f"[run {run_number}] query={query!r}: expected stop_reason='ask', "
+        f"got {result.stop_reason!r} — content: {result.content!r}"
+    )
+    assert result.kind == "ask", (
+        f"[run {run_number}] query={query!r}: expected kind='ask', "
+        f"got {result.kind!r} — content: {result.content!r}"
+    )
+    assert "?" in result.content, (
+        f"[run {run_number}] query={query!r}: expected a clarifying question directed "
+        f"at the user, got: {result.content!r}"
+    )
+    assert result.stop_reason not in ("done", "max_remembers"), (
+        f"[run {run_number}] query={query!r}: model must not emit DONE or REMEMBER "
+        f"for genuinely underspecified input, got: {result.stop_reason!r}"
+    )


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds a live eval verifying that a real model correctly identifies genuinely underspecified queries and emits `CLARIFY` rather than hallucinating forward with `DONE` or `REMEMBER`. Uses 3 distinct underspecified queries, each run 3x, for 9 total cases.

## Linked context
Closes #39

## PR Size
- [x] Small (< 100 LOC delta)

## PR Type
- [x] Test

## Context / Motivation
The only existing eval (`test_eval_harness_single_hop`) exercises the `DONE` path. No eval verified that the model correctly routes to `CLARIFY` for genuinely ambiguous inputs. This PR fills that gap.

## Changes
Added `tests/evals/test_eval_clarify.py` with one eval test parameterized across 3 underspecified queries × 3 runs each (9 total):
- Queries: `"help me with it"`, `"what about the other one"`, `"fix this"`; no entity names, no clear intent
- Uses full `Anchor` loop via `ai_fn` fixture, no memory store (retrieval irrelevant for intent-clarification)
- Asserts: `result.stop_reason == "ask"`, `result.kind == "ask"`, `result.content` contains `"?"`, and `stop_reason` is not `"done"` or `"max_remembers"`

## How to test
1. Requires Ollama running locally with `qwen3:4b-instruct` pulled
2. `uv run pytest -m eval tests/evals/test_eval_clarify.py -v`

## Prompt Change Eval Results


Full eval output (optional)


## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
The issue noted the model may fail these tests if the system prompt needs fine-tuning to distinguish unclear intent (CLARIFY) from missing facts (REMEMBER). In practice, `qwen3:4b-instruct` handles all 9 cases correctly without prompt changes. A comment in the test file flags this for future contributors in case a different model is used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added evaluation tests to verify the model properly handles underspecified user queries by requesting clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->