### PR TITLE
feat: add file-format detection utility

### DIFF
--- a/src/anchor/extractors/detect.py
+++ b/src/anchor/extractors/detect.py
@@ -14,7 +14,7 @@ def detect_format(path: str | Path) -> str:
     suffix = Path(path).suffix.lower()
     try:
         return _EXT_MAP[suffix]
-    except KeyError:
+    except KeyError as err:
         raise ValueError(
             f"Unsupported file extension {suffix!r}: cannot detect format for {path!r}"
-        )
+        ) from err

--- a/src/anchor/extractors/detect.py
+++ b/src/anchor/extractors/detect.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_EXT_MAP: dict[str, str] = {
+    ".txt": "text",
+    ".md": "markdown",
+    ".markdown": "markdown",
+}
+
+
+def detect_format(path: str | Path) -> str:
+    """Return the logical format name for *path* based on its file extension."""
+    suffix = Path(path).suffix.lower()
+    try:
+        return _EXT_MAP[suffix]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported file extension {suffix!r}: cannot detect format for {path!r}"
+        )

--- a/tests/evals/test_eval_synthesizer.py
+++ b/tests/evals/test_eval_synthesizer.py
@@ -51,28 +51,28 @@ def test_eval_synthesizer_synthesize(ai_fn, run_number):
 
     # Not empty or a refusal.
     assert output and output.strip(), f"[run {run_number}] output was empty"
-    assert not any(p in output.lower() for p in _REFUSAL_PHRASES), (
-        f"[run {run_number}] output looks like a refusal: {output!r}"
-    )
+    assert not any(
+        p in output.lower() for p in _REFUSAL_PHRASES
+    ), f"[run {run_number}] output looks like a refusal: {output!r}"
 
     # Key facts spanning all three chunks must appear in the synthesis.
     for fact in ("Elena Marsh", "NovaTech", "Prism", "satellite"):
-        assert fact.lower() in output.lower(), (
-            f"[run {run_number}] missing expected fact {fact!r}: {output!r}"
-        )
+        assert (
+            fact.lower() in output.lower()
+        ), f"[run {run_number}] missing expected fact {fact!r}: {output!r}"
 
     # Current question asks about the founder — must be addressed.
-    assert "elena" in output.lower() or "founder" in output.lower(), (
-        f"[run {run_number}] founder topic not addressed: {output!r}"
-    )
+    assert (
+        "elena" in output.lower() or "founder" in output.lower()
+    ), f"[run {run_number}] founder topic not addressed: {output!r}"
 
     # Current question asks about the main product — must be addressed.
-    assert "prism" in output.lower() or "satellite" in output.lower(), (
-        f"[run {run_number}] product topic not addressed: {output!r}"
-    )
+    assert (
+        "prism" in output.lower() or "satellite" in output.lower()
+    ), f"[run {run_number}] product topic not addressed: {output!r}"
 
     # Model must not hallucinate entities absent from the input chunks.
     for entity in _ABSENT_ENTITIES:
-        assert entity.lower() not in output.lower(), (
-            f"[run {run_number}] hallucinated entity {entity!r}: {output!r}"
-        )
+        assert (
+            entity.lower() not in output.lower()
+        ), f"[run {run_number}] hallucinated entity {entity!r}: {output!r}"

--- a/tests/unit/test_detect_format.py
+++ b/tests/unit/test_detect_format.py
@@ -58,5 +58,5 @@ def test_unknown_extension_raises_value_error() -> None:
 
 @pytest.mark.unit
 def test_no_extension_raises_value_error() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Unsupported file extension"):
         detect_format("Makefile")

--- a/tests/unit/test_detect_format.py
+++ b/tests/unit/test_detect_format.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from anchor.extractors.detect import detect_format
+
+
+# ---------------------------------------------------------------------------
+# known extensions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_txt_returns_text() -> None:
+    assert detect_format("notes.txt") == "text"
+
+
+@pytest.mark.unit
+def test_md_returns_markdown() -> None:
+    assert detect_format("readme.md") == "markdown"
+
+
+@pytest.mark.unit
+def test_markdown_extension_returns_markdown() -> None:
+    assert detect_format("guide.markdown") == "markdown"
+
+
+# ---------------------------------------------------------------------------
+# case-insensitive handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_uppercase_txt_returns_text() -> None:
+    assert detect_format("notes.TXT") == "text"
+
+
+@pytest.mark.unit
+def test_uppercase_md_returns_markdown() -> None:
+    assert detect_format("readme.MD") == "markdown"
+
+
+@pytest.mark.unit
+def test_uppercase_markdown_returns_markdown() -> None:
+    assert detect_format("guide.MARKDOWN") == "markdown"
+
+
+# ---------------------------------------------------------------------------
+# error cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unknown_extension_raises_value_error() -> None:
+    with pytest.raises(ValueError, match=r"\.pdf"):
+        detect_format("report.pdf")
+
+
+@pytest.mark.unit
+def test_no_extension_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        detect_format("Makefile")


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds `detect_format(path: str | Path) -> str` in a new `src/anchor/extractors/` package. Returns `"text"` for `.txt` and `"markdown"` for `.md`/`.markdown`, with case-insensitive extension handling and a clear `ValueError` for unknown extensions.

## Linked context
Closes #62

<!-- REQUIRED -->
<!-- Keep this heading name: automation reads it -->
Closes # or Related to # or Supersedes #

## PR Size

<!-- REQUIRED: check one -->

- [x] Small (< 100 LOC delta)
- [ ] Medium (100-499 LOC delta)
- [ ] Large (500-999 LOC delta)
- [ ] XL (1000+ LOC delta — must have been pre-discussed in an issue)

## PR Type
- [x] New feature

## Context / Motivation
A format detection utility is needed to route files to the correct extractor once text and Markdown extractors exist. This PR adds the utility in isolation, independent of chunking, ingestion, or any extractor registry.

## Changes
- `src/anchor/extractors/__init__.py`: empty init making it a proper package
- `src/anchor/extractors/detect.py`: `detect_format` maps lowercased file extension via a dict; `.txt` → `"text"`, `.md`/`.markdown` → `"markdown"`, unknown/missing raises `ValueError`
- `tests/unit/test_detect_format.py`: 8 unit tests covering known extensions, case-insensitive variants, unknown extension, and no extension

## How to test
1. `uv run pytest -m unit -v`
2. All 8 tests in `test_detect_format.py` should pass; full unit suite (88 tests) passes with no regressions

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
PDF, DOCX, and HTML detection are intentionally out of scope per the issue. The `_EXT_MAP` dict in `detect.py` is the natural extension point when those extractors are added; each new format is one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic format detection capability that recognizes common file extensions and maps them to format types, supporting text and markdown with case-insensitive handling.

* **Tests**
  * Added unit tests for format detection covering supported extensions, case variations, and error handling for unsupported file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->