### PR TITLE
test: add ingestion pipeline integration test scaffolding

### DIFF
--- a/tests/fixtures/ingestion/sample.md
+++ b/tests/fixtures/ingestion/sample.md
@@ -1,0 +1,5 @@
+# About Anchor
+
+Anchor is a personal AI assistant that helps users capture and retrieve knowledge.
+
+It uses vector embeddings to store and search through past conversations.

--- a/tests/fixtures/ingestion/sample.txt
+++ b/tests/fixtures/ingestion/sample.txt
@@ -1,0 +1,3 @@
+Anchor is a personal AI assistant designed to help users capture and retrieve knowledge.
+It stores information as vector embeddings in a memory store.
+Users can query the assistant to find relevant facts from previous conversations.

--- a/tests/integration/test_ingestion_pipeline.py
+++ b/tests/integration/test_ingestion_pipeline.py
@@ -24,24 +24,9 @@ def _run_ingest(filename: str) -> tuple[str, str, FakeMemoryStore]:
 
 
 @pytest.mark.unit
-def test_ingest_txt_file() -> None:
-    chunk_id, filepath, store = _run_ingest("sample.txt")
-
-    chunk = store.get(chunk_id)
-    assert chunk is not None
-    assert chunk["metadata"]["source"] == filepath
-    assert chunk["metadata"]["questions"]
-    assert chunk["metadata"]["timestamp"]
-
-    embedding = deterministic_embedding(Path(filepath).read_text())
-    results = store.query(embedding, top_k=1)
-    assert len(results) == 1
-    assert results[0]["id"] == chunk_id
-
-
-@pytest.mark.unit
-def test_ingest_md_file() -> None:
-    chunk_id, filepath, store = _run_ingest("sample.md")
+@pytest.mark.parametrize("filename", ["sample.txt", "sample.md"])
+def test_ingest_file(filename: str) -> None:
+    chunk_id, filepath, store = _run_ingest(filename)
 
     chunk = store.get(chunk_id)
     assert chunk is not None

--- a/tests/integration/test_ingestion_pipeline.py
+++ b/tests/integration/test_ingestion_pipeline.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from anchor.ingestor import Ingestor
+from tests.unit_harness import FakeMemoryStore, deterministic_embedding
+
+_FIXTURES = Path(__file__).parent.parent / "fixtures" / "ingestion"
+
+
+def _run_ingest(filename: str) -> tuple[str, str, FakeMemoryStore]:
+    filepath = str(_FIXTURES / filename)
+    content = Path(filepath).read_text()
+    store = FakeMemoryStore(allow_fallback_query=True)
+    ingestor = Ingestor(
+        memory_store=store,
+        embed_fn=deterministic_embedding,
+        question_fn=lambda _msgs: "What is this about?",
+    )
+    chunk_id = ingestor.ingest(content, source=filepath)
+    return chunk_id, filepath, store
+
+
+@pytest.mark.unit
+def test_ingest_txt_file() -> None:
+    chunk_id, filepath, store = _run_ingest("sample.txt")
+
+    chunk = store.get(chunk_id)
+    assert chunk is not None
+    assert chunk["metadata"]["source"] == filepath
+    assert chunk["metadata"]["questions"]
+    assert chunk["metadata"]["timestamp"]
+
+    embedding = deterministic_embedding(Path(filepath).read_text())
+    results = store.query(embedding, top_k=1)
+    assert len(results) == 1
+    assert results[0]["id"] == chunk_id
+
+
+@pytest.mark.unit
+def test_ingest_md_file() -> None:
+    chunk_id, filepath, store = _run_ingest("sample.md")
+
+    chunk = store.get(chunk_id)
+    assert chunk is not None
+    assert chunk["metadata"]["source"] == filepath
+    assert chunk["metadata"]["questions"]
+    assert chunk["metadata"]["timestamp"]
+
+    embedding = deterministic_embedding(Path(filepath).read_text())
+    results = store.query(embedding, top_k=1)
+    assert len(results) == 1
+    assert results[0]["id"] == chunk_id


### PR DESCRIPTION
# Pull Request

Use a Conventional Commit title: `feat: ...`, `fix: ...`, `docs: ...`, `chore: ...`, `refactor: ...`, `test: ...`, `build: ...`, `ci: ...`, `perf: ...`, or `revert: ...`.

## Summary
Adds offline integration test scaffolding for the extractor-to-ingest flow. Creates fixture files for plain text and Markdown, a new `tests/integration/` package, and two deterministic tests that verify the current minimal ingestion path end-to-end.

## Linked context
Closes #63

<!-- REQUIRED -->
<!-- Keep this heading name: automation reads it -->
Closes # or Related to # or Supersedes #

## PR Size

<!-- REQUIRED: check one -->

- [X] Small (< 100 LOC delta)
- [ ] Medium (100-499 LOC delta)
- [ ] Large (500-999 LOC delta)
- [ ] XL (1000+ LOC delta — must have been pre-discussed in an issue)

## PR Type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Prompt change (`prompt` label required; eval results required below)
- [X] Test
- [ ] Docs
- [ ] Refactor / chore

## Context / Motivation
Future chunking and extractor work needs a place to plug in. This PR establishes the test structure and verifies the current adapter path (`read file → Ingestor.ingest(content, source)`) without pretending full document metadata can flow through yet.

## Changes
- `tests/fixtures/ingestion/sample.txt` - plain text fixture (3 sentences about Anchor)
- `tests/fixtures/ingestion/sample.md` - Markdown fixture with a heading and 2 body lines
- `tests/integration/__init__.py` - empty init, mirrors `tests/unit/` pattern
- `tests/integration/test_ingestion_pipeline.py` - 2 `@pytest.mark.unit` offline tests covering `.txt` and `.md` ingestion; uses `FakeMemoryStore` and `deterministic_embedding` from `unit_harness`; asserts `source`, `questions`, and `timestamp` metadata fields exist and the chunk is retrievable via `store.query()`

## How to test
1. `uv run pytest -m unit -v`
2. Both tests in `test_ingestion_pipeline.py` pass with no network or Ollama dependency; full unit suite (90 tests) passes with no regressions

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
The `question_fn` is a simple lambda returning a fixed string; the goal is to verify metadata persistence, not question generation quality. The `allow_fallback_query=True` flag on `FakeMemoryStore` enables `store.query()` to return stored items without requiring pre-seeded query results, which is the right behavior for an integration test that ingests real content. When actual text/Markdown extractors land, the `_run_ingest` helper can be updated to route through them without changing the assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for the ingestion pipeline, verifying proper handling of text and markdown file formats with vector embedding storage and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->