### PR TITLE
feat: implement Markdown extractor with mistune

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "python-dotenv>=1.2.2",
 ]
 
+[project.optional-dependencies]
+ingestion = ["mistune>=3.0"]
+
 [project.urls]
 Homepage = "https://github.com/Codelab-Davis/Anchor"
 Repository = "https://github.com/Codelab-Davis/Anchor"

--- a/src/anchor/extractors/__init__.py
+++ b/src/anchor/extractors/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class NormalizedDocument:
+    content: str
+    source: str
+    source_format: str
+    metadata: dict = field(default_factory=dict)

--- a/src/anchor/extractors/markdown.py
+++ b/src/anchor/extractors/markdown.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import mistune
+
+from anchor.extractors import NormalizedDocument
+
+
+# Design choice: returns one NormalizedDocument per section, where a section begins
+# at each heading. Content before the first heading is emitted as its own section
+# with no heading metadata. This aligns with the chunk-metadata schema's heading/section
+# fields and keeps each document semantically coherent for downstream use.
+
+
+def _inline_text(children: list[dict]) -> str:
+    parts = []
+    for child in children:
+        if "raw" in child:
+            parts.append(child["raw"])
+        if child.get("children"):
+            parts.append(_inline_text(child["children"]))
+    return "".join(parts)
+
+
+def _tokens_to_text(tokens: list[dict]) -> str:
+    parts = []
+    for tok in tokens:
+        t = tok["type"]
+        if t == "blank_line":
+            continue
+        elif t == "block_code":
+            lang = (tok.get("attrs") or {}).get("info") or ""
+            parts.append(f"```{lang}\n{tok['raw']}```")
+        elif t == "paragraph":
+            parts.append(_inline_text(tok.get("children", [])))
+        elif t == "heading":
+            level = (tok.get("attrs") or {}).get("level", 1)
+            parts.append("#" * level + " " + _inline_text(tok.get("children", [])))
+        elif "raw" in tok:
+            parts.append(tok["raw"])
+    return "\n\n".join(p for p in parts if p)
+
+
+def _heading_label(token: dict) -> str:
+    level = (token.get("attrs") or {}).get("level", 1)
+    return "#" * level + " " + _inline_text(token.get("children", []))
+
+
+@dataclass
+class _Section:
+    heading_token: dict | None
+    body_tokens: list[dict]
+
+
+class MarkdownExtractor:
+    def __init__(self) -> None:
+        self._md = mistune.create_markdown(renderer="ast")
+
+    def extract(self, path: str | Path) -> list[NormalizedDocument]:
+        path = Path(path)
+        raw = path.read_text(encoding="utf-8")
+        tokens: list[dict] = self._md(raw)  # type: ignore[assignment]
+
+        sections: list[_Section] = []
+        current_heading: dict | None = None
+        current_body: list[dict] = []
+
+        for tok in tokens:
+            if tok["type"] == "heading":
+                if current_heading is not None or current_body:
+                    sections.append(_Section(current_heading, current_body))
+                current_heading = tok
+                current_body = []
+            else:
+                current_body.append(tok)
+
+        if current_heading is not None or current_body:
+            sections.append(_Section(current_heading, current_body))
+
+        docs: list[NormalizedDocument] = []
+        for section in sections:
+            if section.heading_token is not None:
+                content_tokens = [section.heading_token] + section.body_tokens
+                metadata = {"heading": _heading_label(section.heading_token)}
+            else:
+                content_tokens = section.body_tokens
+                metadata = {}
+
+            content = _tokens_to_text(content_tokens)
+            if not content.strip():
+                continue
+
+            docs.append(
+                NormalizedDocument(
+                    content=content,
+                    source=str(path),
+                    source_format="markdown",
+                    metadata=metadata,
+                )
+            )
+
+        return docs

--- a/src/anchor/extractors/markdown.py
+++ b/src/anchor/extractors/markdown.py
@@ -31,8 +31,9 @@ def _tokens_to_text(tokens: list[dict]) -> str:
         if t == "blank_line":
             continue
         elif t == "block_code":
+            marker = tok.get("marker", "```")
             lang = (tok.get("attrs") or {}).get("info") or ""
-            parts.append(f"```{lang}\n{tok['raw']}```")
+            parts.append(f"{marker}{lang}\n{tok['raw']}{marker}")
         elif t == "paragraph":
             parts.append(_inline_text(tok.get("children", [])))
         elif t == "heading":

--- a/tests/unit/test_markdown_extractor.py
+++ b/tests/unit/test_markdown_extractor.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from anchor.extractors import NormalizedDocument
+from anchor.extractors.markdown import MarkdownExtractor
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def run_extract(tmp_path: Path, content: str) -> list[NormalizedDocument]:
+    md_file = tmp_path / "sample.md"
+    md_file.write_text(textwrap.dedent(content), encoding="utf-8")
+    return MarkdownExtractor().extract(md_file)
+
+
+# ---------------------------------------------------------------------------
+# multiple headings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_multiple_headings_produces_one_doc_per_section(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        # Alpha
+
+        First section content.
+
+        ## Beta
+
+        Second section content.
+
+        ## Gamma
+
+        Third section content.
+        """,
+    )
+    assert len(docs) == 3
+
+
+@pytest.mark.unit
+def test_heading_metadata_is_correct_per_section(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        # Alpha
+
+        First.
+
+        ## Beta
+
+        Second.
+        """,
+    )
+    assert docs[0].metadata["heading"] == "# Alpha"
+    assert docs[1].metadata["heading"] == "## Beta"
+
+
+@pytest.mark.unit
+def test_heading_level_reflected_in_metadata(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        ### Deep Heading
+
+        Some content.
+        """,
+    )
+    assert docs[0].metadata["heading"] == "### Deep Heading"
+
+
+@pytest.mark.unit
+def test_section_content_contains_expected_text(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        # Title
+
+        Introduction paragraph.
+
+        ## Details
+
+        Detail paragraph.
+        """,
+    )
+    assert "Introduction paragraph." in docs[0].content
+    assert "Detail paragraph." in docs[1].content
+
+
+@pytest.mark.unit
+def test_source_format_is_markdown(tmp_path: Path) -> None:
+    docs = run_extract(tmp_path, "# Hello\n\nWorld.\n")
+    assert all(doc.source_format == "markdown" for doc in docs)
+
+
+@pytest.mark.unit
+def test_source_is_file_path(tmp_path: Path) -> None:
+    md_file = tmp_path / "sample.md"
+    md_file.write_text("# Hello\n\nWorld.\n", encoding="utf-8")
+    docs = MarkdownExtractor().extract(md_file)
+    assert all(doc.source == str(md_file) for doc in docs)
+
+
+# ---------------------------------------------------------------------------
+# content before first heading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_preamble_before_first_heading_is_extracted(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        Preamble text before any heading.
+
+        ## First Heading
+
+        Section content.
+        """,
+    )
+    assert len(docs) == 2
+    assert "Preamble text before any heading." in docs[0].content
+
+
+@pytest.mark.unit
+def test_preamble_section_has_no_heading_metadata(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        Preamble.
+
+        ## Heading
+
+        Content.
+        """,
+    )
+    assert "heading" not in docs[0].metadata
+
+
+@pytest.mark.unit
+def test_preamble_only_document_has_no_heading_metadata(tmp_path: Path) -> None:
+    docs = run_extract(tmp_path, "No headings here at all.\n")
+    assert len(docs) == 1
+    assert "heading" not in docs[0].metadata
+
+
+# ---------------------------------------------------------------------------
+# fenced code blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fenced_code_block_content_preserved_verbatim(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        ## Code Section
+
+        ```python
+        def foo():
+            pass
+        ```
+        """,
+    )
+    assert len(docs) == 1
+    content = docs[0].content
+    assert "def foo():" in content
+    assert "    pass" in content  # 4-space indentation must survive
+
+
+@pytest.mark.unit
+def test_fenced_code_block_without_heading(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        Some prose.
+
+        ```
+        plain block
+            indented line
+        ```
+        """,
+    )
+    assert len(docs) == 1
+    content = docs[0].content
+    assert "plain block" in content
+    assert "    indented line" in content
+
+
+@pytest.mark.unit
+def test_fenced_code_with_multiline_body(tmp_path: Path) -> None:
+    docs = run_extract(
+        tmp_path,
+        """\
+        ## Snippet
+
+        ```python
+        x = 1
+        y = 2
+        z = x + y
+        ```
+        """,
+    )
+    content = docs[0].content
+    assert "x = 1" in content
+    assert "y = 2" in content
+    assert "z = x + y" in content

--- a/tests/unit/test_markdown_extractor.py
+++ b/tests/unit/test_markdown_extractor.py
@@ -172,6 +172,7 @@ def test_fenced_code_block_content_preserved_verbatim(tmp_path: Path) -> None:
     )
     assert len(docs) == 1
     content = docs[0].content
+    assert "```python" in content
     assert "def foo():" in content
     assert "    pass" in content  # 4-space indentation must survive
 
@@ -191,6 +192,7 @@ def test_fenced_code_block_without_heading(tmp_path: Path) -> None:
     )
     assert len(docs) == 1
     content = docs[0].content
+    assert "```" in content
     assert "plain block" in content
     assert "    indented line" in content
 
@@ -210,6 +212,23 @@ def test_fenced_code_with_multiline_body(tmp_path: Path) -> None:
         """,
     )
     content = docs[0].content
+    assert "```python" in content
     assert "x = 1" in content
     assert "y = 2" in content
     assert "z = x + y" in content
+
+
+# ---------------------------------------------------------------------------
+# file extension variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_markdown_extension_is_extracted(tmp_path: Path) -> None:
+    md_file = tmp_path / "guide.markdown"
+    md_file.write_text("# Title\n\nContent.\n", encoding="utf-8")
+    docs = MarkdownExtractor().extract(md_file)
+    assert len(docs) == 1
+    assert docs[0].source_format == "markdown"
+    assert docs[0].metadata["heading"] == "# Title"
+    assert docs[0].source == str(md_file)

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,11 @@ dependencies = [
     { name = "python-dotenv" },
 ]
 
+[package.optional-dependencies]
+ingestion = [
+    { name = "mistune" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pip-audit" },
@@ -26,9 +31,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "chromadb", specifier = ">=1.5.9" },
+    { name = "mistune", marker = "extra == 'ingestion'", specifier = ">=3.0" },
     { name = "ollama", specifier = ">=0.6.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
+provides-extras = ["ingestion"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -671,6 +678,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds a Markdown extractor using mistune that returns one `NormalizedDocument` per section, split at each heading. Captures heading text in metadata and preserves fenced code block content verbatim, including indentation.

## Linked context
Closes #61

## PR Size
- [X] Medium (100-499 LOC delta)

## PR Type
- [x] New feature

## Context / Motivation
Anchor needs a document ingestion path that can extract text and metadata from common file formats. This PR adds the Markdown extractor as recommended in issue #48, using mistune instead of regex parsing so heading and code block edge cases are handled correctly.

## Changes
- `pyproject.toml`: added `[project.optional-dependencies]` with `ingestion = ["mistune>=3.0"]`, kept out of core dependencies
- `src/anchor/extractors/__init__.py`: added `NormalizedDocument` dataclass with `content`, `source`, `source_format`, and `metadata` fields
- `src/anchor/extractors/markdown.py`: `MarkdownExtractor.extract(path)` parses a `.md`/`.markdown` file with mistune's AST renderer, splits at each heading into separate documents, sets `source_format="markdown"`, stores heading text in `metadata["heading"]`, and reconstructs fenced code blocks from raw token content to preserve indentation
- `tests/unit/test_markdown_extractor.py`: 12 unit tests covering multi-heading splitting, heading metadata correctness, content before the first heading, and fenced code block preservation

## How to test
1. `pip install anchor[ingestion]` or `pip install mistune --break-system-packages` in this dev environment
2. `uv run pytest -m unit -v`
3. All 12 tests in `test_markdown_extractor.py` pass, full unit suite (98 tests) passes with no regressions

## Checklist
- [x] I ran the relevant local checks.
- [x] I updated documentation or confirmed no docs changes were needed.
- [x] I linked related issues or pull requests and confirmed this is not duplicate work.
- [x] This change stays within the stated scope of the PR.

## Notes for reviewers
Design choice: one document per section rather than one document for the whole file. This keeps each output unit semantically coherent and aligns with the heading/section metadata fields in the chunk metadata schema (docs/architecture/chunk-metadata-schema.md), without depending on the chunking strategy from issue #50. Content before the first heading is emitted as its own section with no heading key in metadata, following the schema's convention of omitting absent fields rather than using empty strings or sentinels. Extraction is not wired into `Ingestor` per the issue scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Markdown ingestion to extract content from Markdown files, splitting output into heading-based sections and preserving fenced code blocks.
  * Each extracted document now includes normalized content, source file path, source format, and heading metadata when applicable.

* **Configuration**
  * Added an optional `ingestion` dependency extra to support Markdown parsing (`mistune>=3.0`).

* **Tests**
  * Expanded unit test coverage for section splitting, heading metadata accuracy, source/source-format reporting, and code block preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->